### PR TITLE
Fix pattern command rule

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -150,7 +150,7 @@ TBD
 <copy_command> ::= [<line_range>] "co" <line_address>
 <line_number_command> ::= [<line_range>] "#"
 <global_command> ::= [<line_range>] "g/" <pattern> "/" <global_option>
-<pattern_command> ::= [<line_range>]**** "t" <line_address>
+<pattern_command> ::= [<line_range>] "t" <line_address>
 
 <line_range> ::= <line_address> | <line_address> "," <line_address> | "%" | <line_address> "," <pattern>
 <line_address> ::= <number> | "." | "$" | "-" | "+"


### PR DESCRIPTION
## Summary
- correct the `<pattern_command>` syntax in `spec.md`

## Testing
- `grep -n "pattern_command" -n doc/spec.md`

------
https://chatgpt.com/codex/tasks/task_e_6842dc681304832f8dbe0a71d7bf5e57