### PR TITLE
Fix LastLine index handling

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -480,10 +480,10 @@ impl Editor {
             },
             crate::data::LineAddressType::Absolute(SimpleLineAddressType::FirstLine) => 0,
             crate::data::LineAddressType::Absolute(SimpleLineAddressType::LastLine) => {
-                self.buffer.lines.len() as isize
+                self.buffer.lines.len().saturating_sub(1) as isize
             },
             crate::data::LineAddressType::Absolute(SimpleLineAddressType::AllLines) => {
-                self.buffer.lines.len() as isize
+                self.buffer.lines.len().saturating_sub(1) as isize
             },
             crate::data::LineAddressType::Absolute(SimpleLineAddressType::Pattern(_)) => {
                 // TODO: Implement
@@ -499,10 +499,10 @@ impl Editor {
                 (self.cursor_position_in_buffer.row as isize) + i
             },
             crate::data::LineAddressType::Relative(SimpleLineAddressType::LastLine, i) => {
-                (self.buffer.lines.len() as isize) + i
+                (self.buffer.lines.len().saturating_sub(1) as isize) + i
             },
             crate::data::LineAddressType::Relative(SimpleLineAddressType::AllLines, i) => {
-                (self.buffer.lines.len() as isize) + i
+                (self.buffer.lines.len().saturating_sub(1) as isize) + i
             },
             crate::data::LineAddressType::Relative(SimpleLineAddressType::Pattern(_), i) => {
                 // TODO: Implement
@@ -561,11 +561,11 @@ mod tests {
         );
         assert_eq!(
             editor.get_line_number_from(&LineAddressType::Absolute(SimpleLineAddressType::LastLine)),
-            3
+            2
         );
         assert_eq!(
             editor.get_line_number_from(&LineAddressType::Absolute(SimpleLineAddressType::AllLines)),
-            3
+            2
         );
     }
 


### PR DESCRIPTION
## Summary
- fix line number calculations for `LastLine` and `AllLines`
- update tests for new final line index logic

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6842dc74be1c832f85cdf4392f23455c