### PR TITLE
Add TODO list and describe implemented vi commands

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -36,7 +36,21 @@ evi is a vi clone editor written in Rust. It is a simple and lightweight text ed
 
 ## vi commands
 
-TBD
+The following commands are currently implemented:
+
+- `h`, `j`, `k`, `l` — move the cursor left, down, up and right
+- `0`, `$` — jump to the beginning or end of the current line
+- `w`, `b` — move forward or backward by word
+- `i` — insert text before the cursor
+- `a` — append text after the cursor
+- `x` — delete the character under the cursor
+- `d{motion}` — delete text specified by a motion
+- `u` — undo the last change
+- `Ctrl-g` — display file information
+- `ZZ` — write the file if modified and exit
+- `:` — enter ex command mode
+
+All other POSIX vi commands are not yet implemented.
 
 ## ex commands
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,36 @@
+# TODO
+
+This document lists vi and ex commands from the POSIX vi specification that are not yet implemented in evi.
+
+## Unimplemented vi commands
+
+- `o`, `O` – open a new line below/above the current line
+- `I`, `A` – insert/append at the beginning/end of line
+- `c`, `cc`, `cw`, `C` – change commands
+- `y`, `yy`, `yw` – yank operations
+- `p`, `P` – paste text from the unnamed buffer
+- `r`, `R` – replace character or enter replace mode
+- `J` – join lines
+- `/`, `?`, `n`, `N` – search motions
+- `f`, `F`, `t`, `T` – find character on the current line
+- `o`/`O` – open new line in command mode
+- Visual mode commands such as `v`, `V`
+- Marks (`m`{char}) and jumps (`'{char}`)
+- Macros (`@`{register})
+
+## Unimplemented ex commands
+
+The ex commands described in `doc/spec.md` but not yet implemented include:
+
+- `:w` and `:w!` – write buffer to file (with or without force)
+- `:e!` – reload file discarding changes
+- `:x` – write if modified and exit
+- `:r {file}` – read another file into the buffer
+- `:m` and `:co` – move or copy lines
+- `:set number`, `:set nonumber`, `:set nu`, `:set nonu`
+- `:#`, `:=`, `:.=` and `:/pattern/=` – line number related commands
+- Global search commands `:g` and `:g!`
+- Line range addresses using patterns or relative offsets (`+`, `-`) are not handled
+- Printing with `:p` and related range forms (implementation pending)
+
+These items are targets for future development in order to be closer to a full POSIX vi clone.


### PR DESCRIPTION
## Summary
- add docs/todo.md summarising missing vi/ex commands
- document currently implemented vi commands in doc/spec.md

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684357ea760c832f8fcf05f7a7e11535