### PR TITLE
Implement ex :x command

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -23,7 +23,7 @@ The ex commands described in `doc/spec.md` but not yet implemented include:
 
 - `:w` and `:w!` – write buffer to file (with or without force)
 - `:e!` – reload file discarding changes
-- `:x` – write if modified and exit
+- ~~`:x` – write if modified and exit~~
 - `:r {file}` – read another file into the buffer
 - `:m` and `:co` – move or copy lines
 - `:set number`, `:set nonumber`, `:set nu`, `:set nonu`


### PR DESCRIPTION
## Summary
- add `:x` to ex parser
- implement `x_command` that writes if modified then exits
- document implemented `:x`
- test new parser logic

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68437d6ac0f0832fbfa2e4675ac65e1f