### PR TITLE
Implement basic replace commands

### DIFF
--- a/src/command/commands/esc.rs
+++ b/src/command/commands/esc.rs
@@ -7,10 +7,8 @@ use crate::generic_error::GenericResult;
 pub struct Esc;
 impl Command for Esc {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        if editor.is_insert_mode() || editor.is_replace_mode() || editor.is_replace_char_mode() {
-            editor.set_command_mode();
-        } else {
-            editor.set_command_mode();
+        editor.set_command_mode();
+        if !editor.is_insert_mode() && !editor.is_replace_mode() && !editor.is_replace_char_mode() {
             editor.display_visual_bell()?;
         }
         editor.status_line = "".to_string();

--- a/src/command/commands/esc.rs
+++ b/src/command/commands/esc.rs
@@ -7,7 +7,7 @@ use crate::generic_error::GenericResult;
 pub struct Esc;
 impl Command for Esc {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        if editor.is_insert_mode() {
+        if editor.is_insert_mode() || editor.is_replace_mode() || editor.is_replace_char_mode() {
             editor.set_command_mode();
         } else {
             editor.set_command_mode();

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -11,6 +11,8 @@ pub mod no_op_command;
 pub mod open_line;
 pub mod print;
 pub mod paste;
+pub mod replace;
+pub mod replace_char;
 pub mod search;
 pub mod substitute;
 pub mod yank;

--- a/src/command/commands/replace.rs
+++ b/src/command/commands/replace.rs
@@ -1,0 +1,27 @@
+use std::any::Any;
+
+use crate::command::base::Command;
+use crate::editor::Editor;
+use crate::generic_error::GenericResult;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Replace;
+
+impl Command for Replace {
+    fn is_reusable(&self) -> bool {
+        false
+    }
+
+    fn is_modeful(&self) -> bool {
+        true
+    }
+
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.set_replace_mode();
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/commands/replace_char.rs
+++ b/src/command/commands/replace_char.rs
@@ -1,0 +1,27 @@
+use std::any::Any;
+
+use crate::command::base::Command;
+use crate::editor::Editor;
+use crate::generic_error::GenericResult;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ReplaceChar;
+
+impl Command for ReplaceChar {
+    fn is_reusable(&self) -> bool {
+        false
+    }
+
+    fn is_modeful(&self) -> bool {
+        true
+    }
+
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.set_replace_char_mode();
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -148,6 +148,16 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             ..
         } => Box::new(Paste { before: true, ..Default::default() }),
 
+        CommandData {
+            key_code: KeyCode::Char('r'),
+            ..
+        } => Box::new(super::commands::replace_char::ReplaceChar {}),
+
+        CommandData {
+            key_code: KeyCode::Char('R'),
+            ..
+        } => Box::new(super::commands::replace::Replace::default()),
+
         // undo command
         CommandData {
             key_code: KeyCode::Char('u'),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -280,6 +280,7 @@ impl Editor {
             Mode::Insert => {
                 self.mode = Mode::Replace;
                 self.status_line = "-- REPLACE --".to_string();
+                self.last_input_string = String::new();
             }
             Mode::Replace => {}
             Mode::ExCommand => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -297,6 +297,7 @@ impl Editor {
 
     pub fn set_replace_char_mode(&mut self) {
         self.mode = Mode::ReplaceChar;
+        self.status_line = "-- REPLACE CHAR --".to_string();
         self.last_input_string = String::new();
     }
 

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -97,6 +97,57 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.append_search_query(key_data);
                         }
                     }
+                } else if editor.is_replace_char_mode() {
+                    match key_event.code {
+                        event::KeyCode::Esc => {
+                            editor.set_command_mode();
+                            editor.status_line = "".to_string();
+                        }
+                        event::KeyCode::Char(c) => {
+                            editor.replace_char_at_cursor(c)?;
+                            editor.set_command_mode();
+                        }
+                        _ => {}
+                    }
+                } else if editor.is_replace_mode() {
+                    let key_data: KeyData = key_event.into();
+                    match key_data {
+                        KeyData {
+                            key_code: event::KeyCode::Enter,
+                            ..
+                        } => {
+                            editor.append_new_line()?;
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Esc,
+                            ..
+                        } => {
+                            editor.set_command_mode();
+                            editor.status_line = "".to_string();
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Backspace,
+                            ..
+                        }
+                        | KeyData {
+                            key_code: event::KeyCode::Char('h'),
+                            modifiers: KeyModifiers::CONTROL,
+                        } => {
+                            editor.backward_delete_char()?;
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Char('l'),
+                            modifiers: KeyModifiers::CONTROL,
+                            ..
+                        } => {
+                            editor.render(&mut stdout)?;
+                        }
+                        _ => {
+                            if let crossterm::event::KeyCode::Char(c) = key_event.code {
+                                editor.replace_char_and_move(c)?;
+                            }
+                        }
+                    }
                 } else if editor.is_insert_mode() {
                     let key_data: KeyData = key_event.into();
                     match key_data {


### PR DESCRIPTION
## Summary
- add Replace and ReplaceChar commands
- extend editor modes for replace functionality
- handle replace commands in main loop and Esc
- include new modules in factory

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6843932e4a30832f83ee54d446e919d8