### PR TITLE
Implement basic replace commands

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -9,7 +9,7 @@ This document lists vi and ex commands from the POSIX vi specification that are 
 - ~~`c`, `cc`, `cw`, `C` – change commands~~
 - ~~`y`, `yy`, `yw` – yank operations~~
 - ~~`p`, `P` – paste text from the unnamed buffer~~
-- `r`, `R` – replace character or enter replace mode
+- ~~`r`, `R` – replace character or enter replace mode~~
 - `J` – join lines
 - ~~`/`, `?`, `n`, `N` – search motions~~
 - `f`, `F`, `t`, `T` – find character on the current line

--- a/src/command/base.rs
+++ b/src/command/base.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 
-use crate::{data::LineRange, editor::Editor, generic_error::GenericResult};
+use crate::{editor::Editor, generic_error::GenericResult};
 
 pub trait Command {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()>;

--- a/src/command/base.rs
+++ b/src/command/base.rs
@@ -35,9 +35,11 @@ pub trait Command {
         // do nothing
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     fn as_any(&self) -> &dyn Any;
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl dyn Command {
     pub fn is<T: Command + 'static>(&self) -> bool {
         self.as_any().is::<T>()

--- a/src/command/commands/esc.rs
+++ b/src/command/commands/esc.rs
@@ -7,7 +7,7 @@ use crate::generic_error::GenericResult;
 pub struct Esc;
 impl Command for Esc {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        if editor.is_insert_mode() {
+        if editor.is_insert_mode() || editor.is_replace_mode() || editor.is_replace_char_mode() {
             editor.set_command_mode();
         } else {
             editor.set_command_mode();

--- a/src/command/commands/go_to_line.rs
+++ b/src/command/commands/go_to_line.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use crate::command::base::Command;
 use crate::command::commands::move_cursor::NextLine;
-use crate::data::{LineAddressType, LineRange, SimpleLineAddressType};
+use crate::data::LineAddressType;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -11,6 +11,8 @@ pub mod no_op_command;
 pub mod open_line;
 pub mod print;
 pub mod paste;
+pub mod replace;
+pub mod replace_char;
 pub mod search;
 pub mod substitute;
 pub mod yank;

--- a/src/command/commands/print.rs
+++ b/src/command/commands/print.rs
@@ -6,6 +6,7 @@ use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
 pub struct PrintCommand {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub line_range: LineRange
 }
 

--- a/src/command/commands/print.rs
+++ b/src/command/commands/print.rs
@@ -10,7 +10,7 @@ pub struct PrintCommand {
 }
 
 impl Command for PrintCommand {
-    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+    fn execute(&mut self, _editor: &mut Editor) -> GenericResult<()> {
         // TODO: Implement PrintCommand
         log::info!("PrintCommand execute");
         Ok(())

--- a/src/command/commands/replace.rs
+++ b/src/command/commands/replace.rs
@@ -1,0 +1,27 @@
+use std::any::Any;
+
+use crate::command::base::Command;
+use crate::editor::Editor;
+use crate::generic_error::GenericResult;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Replace;
+
+impl Command for Replace {
+    fn is_reusable(&self) -> bool {
+        false
+    }
+
+    fn is_modeful(&self) -> bool {
+        true
+    }
+
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.set_replace_mode();
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/commands/replace_char.rs
+++ b/src/command/commands/replace_char.rs
@@ -5,7 +5,15 @@ use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ReplaceChar;
+pub struct ReplaceChar {
+    pub count: usize,
+}
+
+impl Default for ReplaceChar {
+    fn default() -> Self {
+        Self { count: 1 }
+    }
+}
 
 impl Command for ReplaceChar {
     fn is_reusable(&self) -> bool {
@@ -17,7 +25,7 @@ impl Command for ReplaceChar {
     }
 
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        editor.set_replace_char_mode();
+        editor.set_replace_char_mode_with_count(self.count);
         Ok(())
     }
 

--- a/src/command/commands/replace_char.rs
+++ b/src/command/commands/replace_char.rs
@@ -1,0 +1,27 @@
+use std::any::Any;
+
+use crate::command::base::Command;
+use crate::editor::Editor;
+use crate::generic_error::GenericResult;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ReplaceChar;
+
+impl Command for ReplaceChar {
+    fn is_reusable(&self) -> bool {
+        false
+    }
+
+    fn is_modeful(&self) -> bool {
+        true
+    }
+
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.set_replace_char_mode();
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/commands/search.rs
+++ b/src/command/commands/search.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use crate::command::base::Command;
-use crate::editor::{Editor, SearchDirection};
+use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
 pub struct RepeatSearch {

--- a/src/command/commands/write.rs
+++ b/src/command/commands/write.rs
@@ -6,6 +6,7 @@ use crate::generic_error::GenericResult;
 
 #[derive(Default)]
 pub struct WriteCommand {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub force: bool,
 }
 

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -152,7 +152,9 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             key_code: KeyCode::Char('r'),
             modifiers: KeyModifiers::NONE,
             ..
-        } => Box::new(super::commands::replace_char::ReplaceChar {}),
+        } => Box::new(super::commands::replace_char::ReplaceChar {
+            count: command_data.count,
+        }),
 
         CommandData {
             key_code: KeyCode::Char('R'),

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -2,7 +2,7 @@ use crate::command::base::{Command, CommandData, JumpCommandData};
 use crate::command::commands::exit::ExitCommand;
 use crate::command::commands::move_cursor::*;
 use crate::command::commands::no_op_command::NoOpCommand;
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyModifiers};
 
 use super::commands::append::Append;
 use super::commands::change::Change;
@@ -147,6 +147,18 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             key_code: KeyCode::Char('P'),
             ..
         } => Box::new(Paste { before: true, ..Default::default() }),
+
+        CommandData {
+            key_code: KeyCode::Char('r'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => Box::new(super::commands::replace_char::ReplaceChar {}),
+
+        CommandData {
+            key_code: KeyCode::Char('R'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => Box::new(super::commands::replace::Replace::default()),
 
         // undo command
         CommandData {

--- a/src/data.rs
+++ b/src/data.rs
@@ -38,6 +38,7 @@ pub enum SimpleLineAddressType {
 #[derive(Debug, PartialEq, Clone)]
 pub enum LineAddressType {
     Absolute(SimpleLineAddressType),
+    #[allow(dead_code)]
     Relative(SimpleLineAddressType, isize),
 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -284,7 +284,7 @@ impl Editor {
             Mode::Replace => {}
             Mode::ExCommand => {
                 self.mode = Mode::Replace;
-                self.status_line = "".to_string();
+                self.status_line = "-- REPLACE --".to_string();
             }
             Mode::Search(_) => {
                 self.mode = Mode::Replace;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -290,7 +290,6 @@ impl Editor {
                 self.status_line = "-- REPLACE --".to_string();
             }
     #[allow(dead_code)]
-        self.set_replace_char_mode_with_count(1);
     }
 
     pub fn set_replace_char_mode_with_count(&mut self, count: usize) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -289,6 +289,7 @@ impl Editor {
                 self.mode = Mode::Replace;
                 self.status_line = "-- REPLACE --".to_string();
             }
+    #[allow(dead_code)]
         self.set_replace_char_mode_with_count(1);
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -85,6 +85,7 @@ pub struct Editor {
     pub search_query: String,
     pub last_search_pattern: Option<String>,
     pub last_search_direction: Option<SearchDirection>,
+    pub pending_replace_char_count: usize,
 }
 
 impl Editor {
@@ -112,6 +113,7 @@ impl Editor {
             search_query: String::new(),
             last_search_pattern: None,
             last_search_direction: None,
+            pending_replace_char_count: 1,
         }
     }
 
@@ -176,6 +178,7 @@ impl Editor {
             Mode::ReplaceChar => {
                 self.mode = Mode::Command;
                 self.status_line = "".to_string();
+                self.pending_replace_char_count = 1;
             }
             Mode::Search(_) => {
                 self.mode = Mode::Command;
@@ -286,6 +289,11 @@ impl Editor {
                 self.mode = Mode::Replace;
                 self.status_line = "-- REPLACE --".to_string();
             }
+        self.set_replace_char_mode_with_count(1);
+    }
+
+    pub fn set_replace_char_mode_with_count(&mut self, count: usize) {
+        self.pending_replace_char_count = count;
             Mode::Search(_) => {
                 self.mode = Mode::Replace;
                 self.status_line = "-- REPLACE --".to_string();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -294,13 +294,6 @@ impl Editor {
 
     pub fn set_replace_char_mode_with_count(&mut self, count: usize) {
         self.pending_replace_char_count = count;
-            Mode::Search(_) => {
-                self.mode = Mode::Replace;
-                self.status_line = "-- REPLACE --".to_string();
-                self.last_input_string = String::new();
-                self.search_query.clear();
-            }
-        }
     }
 
     pub fn set_replace_char_mode(&mut self) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -744,7 +744,7 @@ impl Editor {
     pub fn get_line_number_from(&mut self, line_address: &LineAddressType) -> usize {
         let line_number: isize = match line_address {
             crate::data::LineAddressType::Absolute(SimpleLineAddressType::LineNumber(n)) => {
-                let input = (*n as isize);
+                let input = *n as isize;
                 if input == 0 {
                     0
                 } else {
@@ -767,7 +767,7 @@ impl Editor {
             }
             crate::data::LineAddressType::Relative(SimpleLineAddressType::FirstLine, i) => 0 + i,
             crate::data::LineAddressType::Relative(SimpleLineAddressType::LineNumber(n), i) => {
-                (*n as isize) + i
+                *n as isize + i
             }
             crate::data::LineAddressType::Relative(SimpleLineAddressType::CurrentLine, i) => {
                 (self.cursor_position_in_buffer.row as isize) + i
@@ -778,7 +778,7 @@ impl Editor {
             crate::data::LineAddressType::Relative(SimpleLineAddressType::AllLines, i) => {
                 (self.buffer.lines.len().saturating_sub(1) as isize) + i
             }
-            crate::data::LineAddressType::Relative(SimpleLineAddressType::Pattern(_), i) => {
+            crate::data::LineAddressType::Relative(SimpleLineAddressType::Pattern(_), _i) => {
                 // TODO: Implement
                 unimplemented!()
             }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -289,7 +289,13 @@ impl Editor {
                 self.mode = Mode::Replace;
                 self.status_line = "-- REPLACE --".to_string();
             }
-    #[allow(dead_code)]
+            Mode::Search(_) => {
+                self.mode = Mode::Replace;
+                self.status_line = "-- REPLACE --".to_string();
+                self.last_input_string = String::new();
+                self.search_query.clear();
+            }
+        }
     }
 
     pub fn set_replace_char_mode_with_count(&mut self, count: usize) {

--- a/src/ex/lexer.rs
+++ b/src/ex/lexer.rs
@@ -3,6 +3,7 @@ use crate::data::Token;
 
 #[derive(Debug, PartialEq)]
 enum SubstitutionCommandState {
+    #[allow(dead_code)]
     None,
     Command,
     FirstSeparator,
@@ -19,6 +20,7 @@ enum FileCommandState {
     None,
     Command,
     Filename,
+    #[allow(dead_code)]
     End,
 }
 
@@ -48,6 +50,7 @@ impl Lexer {
         self.position += 1;
     }
 
+    #[allow(dead_code)]
     fn peek_char(&self) -> Option<char> {
         if self.position >= self.input.len() {
             None

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -104,7 +104,13 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.status_line = "".to_string();
                         }
                         event::KeyCode::Char(c) => {
-                            editor.replace_char_at_cursor(c)?;
+                            for i in 0..editor.pending_replace_char_count {
+                                if i + 1 == editor.pending_replace_char_count {
+                                    editor.replace_char_at_cursor(c)?;
+                                } else {
+                                    editor.replace_char_and_move(c)?;
+                                }
+                            }
                             editor.set_command_mode();
                         }
                         _ => {}

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -97,6 +97,57 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.append_search_query(key_data);
                         }
                     }
+                } else if editor.is_replace_char_mode() {
+                    match key_event.code {
+                        event::KeyCode::Esc => {
+                            editor.set_command_mode();
+                            editor.status_line = "".to_string();
+                        }
+                        event::KeyCode::Char(c) => {
+                            editor.replace_char_at_cursor(c)?;
+                            editor.set_command_mode();
+                        }
+                        _ => {}
+                    }
+                } else if editor.is_replace_mode() {
+                    let key_data: KeyData = key_event.into();
+                    match key_data {
+                        KeyData {
+                            key_code: event::KeyCode::Enter,
+                            ..
+                        } => {
+                            editor.append_new_line()?;
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Esc,
+                            ..
+                        } => {
+                            editor.set_command_mode();
+                            editor.status_line = "".to_string();
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Backspace,
+                            ..
+                        }
+                        | KeyData {
+                            key_code: event::KeyCode::Char('h'),
+                            modifiers: KeyModifiers::CONTROL,
+                        } => {
+                            editor.backward_delete_char()?;
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Char('l'),
+                            modifiers: KeyModifiers::CONTROL,
+                            ..
+                        } => {
+                            editor.render(&mut stdout)?;
+                        }
+                        _ => {
+                            if let crossterm::event::KeyCode::Char(c) = key_event.code {
+                                editor.replace_char_and_move(c)?;
+                            }
+                        }
+                    }
                 } else if editor.is_insert_mode() {
                     let key_data: KeyData = key_event.into();
                     match key_data {

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,11 +2,10 @@ use std::io::Write;
 
 use crossterm::{
     cursor,
-    style::{self, Attribute},
+    style,
     terminal, QueueableCommand,
 };
 use log::info;
-use regex::Regex;
 
 use crate::{
     editor::{Editor, TerminalSize},


### PR DESCRIPTION
## Summary
- add Replace and ReplaceChar commands
- extend editor modes for replace functionality
- handle replace commands in main loop and Esc
- include new modules in factory
- restrict factory matches for `r` and `R` to KeyModifiers::NONE
- update todo

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6843932e4a30832f83ee54d446e919d8