### PR TITLE
Implement :g and :g! ex command

### DIFF
--- a/src/command/commands/global.rs
+++ b/src/command/commands/global.rs
@@ -1,0 +1,66 @@
+use std::any::Any;
+
+use regex::Regex;
+
+use crate::command::base::Command;
+use crate::data::{LineAddressType, LineRange, SimpleLineAddressType, Token};
+use crate::editor::Editor;
+use crate::ex::parser::Parser;
+use crate::generic_error::{GenericError, GenericResult};
+
+pub struct GlobalCommand {
+    pub line_range: LineRange,
+    pub pattern: String,
+    pub command_tokens: Option<Vec<Token>>,
+    pub invert: bool,
+}
+
+impl Command for GlobalCommand {
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        let re = Regex::new(&self.pattern).map_err(|e| GenericError::from(e.to_string()))?;
+        let start = editor.get_line_number_from(&self.line_range.start);
+        let end = editor.get_line_number_from(&self.line_range.end);
+
+        let mut matched_indices = Vec::new();
+        for i in start..=end {
+            if i >= editor.buffer.lines.len() {
+                continue;
+            }
+            let line = &editor.buffer.lines[i];
+            let is_match = re.is_match(line);
+            if (!self.invert && is_match) || (self.invert && !is_match) {
+                matched_indices.push(i);
+            }
+        }
+
+        let mut offset: isize = 0;
+        for idx in matched_indices {
+            let current = (idx as isize + offset) as usize;
+            if current >= editor.buffer.lines.len() {
+                break;
+            }
+            editor.move_cursor_to(current, 0)?;
+            let before_len = editor.buffer.lines.len();
+            if let Some(tokens) = &self.command_tokens {
+                let mut parser = Parser::from_tokens(tokens.clone());
+                let mut cmd = parser.parse()?;
+                cmd.execute(editor)?;
+            } else {
+                let mut print = crate::command::commands::print::PrintCommand {
+                    line_range: LineRange {
+                        start: LineAddressType::Absolute(SimpleLineAddressType::CurrentLine),
+                        end: LineAddressType::Absolute(SimpleLineAddressType::CurrentLine),
+                    },
+                };
+                print.execute(editor)?;
+            }
+            let after_len = editor.buffer.lines.len();
+            offset += after_len as isize - before_len as isize;
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod delete;
 pub mod esc;
 pub mod exit;
 pub mod find_char;
+pub mod global;
 pub mod go_to_line;
 pub mod insert;
 pub mod misc;

--- a/src/ex/lexer.rs
+++ b/src/ex/lexer.rs
@@ -1,5 +1,5 @@
-use crate::data::TokenType;
 use crate::data::Token;
+use crate::data::TokenType;
 
 #[derive(Debug, PartialEq)]
 enum SubstitutionCommandState {
@@ -606,5 +606,35 @@ mod tests {
         assert_eq!(tokens[4].token_type, TokenType::Command);
         assert_eq!(tokens[4].lexeme, "p");
         assert_eq!(tokens[5].token_type, TokenType::EndOfInput);
+    }
+
+    #[test]
+    fn test_tokenize_global_delete() {
+        let input = "g/foo/d";
+        let tokens = tokenize(input);
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(tokens[0].token_type, TokenType::Command);
+        assert_eq!(tokens[0].lexeme, "g");
+        assert_eq!(tokens[1].token_type, TokenType::AddressPattern);
+        assert_eq!(tokens[1].lexeme, "foo");
+        assert_eq!(tokens[2].token_type, TokenType::Command);
+        assert_eq!(tokens[2].lexeme, "d");
+        assert_eq!(tokens[3].token_type, TokenType::EndOfInput);
+    }
+
+    #[test]
+    fn test_tokenize_global_invert() {
+        let input = "g!/foo/p";
+        let tokens = tokenize(input);
+        assert_eq!(tokens.len(), 5);
+        assert_eq!(tokens[0].token_type, TokenType::Command);
+        assert_eq!(tokens[0].lexeme, "g");
+        assert_eq!(tokens[1].token_type, TokenType::Symbol);
+        assert_eq!(tokens[1].lexeme, "!");
+        assert_eq!(tokens[2].token_type, TokenType::AddressPattern);
+        assert_eq!(tokens[2].lexeme, "foo");
+        assert_eq!(tokens[3].token_type, TokenType::Command);
+        assert_eq!(tokens[3].lexeme, "p");
+        assert_eq!(tokens[4].token_type, TokenType::EndOfInput);
     }
 }

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -208,7 +208,7 @@ impl Parser {
                     if let MyOption::Some(token) = self.pop() {
                         token.lexeme
                     } else {
-                        String::new()
+                        return Err(self.error("pattern expected"));
                     }
                 } else {
                     return Err(self.error("pattern expected"));

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -2,6 +2,7 @@ use std::ops::BitOr;
 
 use crate::command::base::Command;
 use crate::command::commands::delete;
+use crate::command::commands::global;
 use crate::command::commands::go_to_line;
 use crate::command::commands::substitute;
 use crate::data::LineAddressType;
@@ -56,6 +57,17 @@ impl Parser {
     pub fn new(input: &str) -> Self {
         let tokens = lexer::tokenize(input);
         println!("tokens {:?}", tokens);
+        Parser {
+            original_tokens: tokens.clone(),
+            tokens,
+            token_opt: MyOption::None,
+            stack: Vec::new(),
+            command_opt: MyOption::None,
+            line_range_opt: MyOption::None,
+        }
+    }
+
+    pub fn from_tokens(tokens: Vec<Token>) -> Self {
         Parser {
             original_tokens: tokens.clone(),
             tokens,
@@ -152,7 +164,8 @@ impl Parser {
         };
         let command_opt = self.display_command(&line_range)?
             | self.substitute_command(&line_range)?
-            | self.delete_command(&line_range)?;
+            | self.delete_command(&line_range)?
+            | self.global_command(&line_range)?;
         if let MyOption::Some(command) = command_opt {
             return Ok(MyOption::Some(command));
         }
@@ -170,6 +183,67 @@ impl Parser {
                 text: None,
             };
             return Ok(MyOption::Some(Box::new(delete_command)));
+        }
+        Ok(MyOption::None)
+    }
+
+    fn global_command(
+        &mut self,
+        line_range: &LineRange,
+    ) -> Result<MyOption<Box<dyn Command>>, GenericError> {
+        if self.accept(TokenType::Command, "g") {
+            self.pop();
+            let mut invert = false;
+            if self.accept(TokenType::Symbol, "!") || self.accept(TokenType::Command, "!") {
+                self.pop();
+                invert = true;
+            }
+
+            let pattern = if let MyOption::Some(tok) = &self.token_opt {
+                if tok.token_type == TokenType::Pattern
+                    || tok.token_type == TokenType::AddressPattern
+                {
+                    let t_type = tok.token_type.clone();
+                    self.accept_type(t_type);
+                    if let MyOption::Some(token) = self.pop() {
+                        token.lexeme
+                    } else {
+                        String::new()
+                    }
+                } else {
+                    return Err(self.error("pattern expected"));
+                }
+            } else {
+                return Err(self.error("pattern expected"));
+            };
+
+            let mut remaining_tokens = Vec::new();
+            if let MyOption::Some(tok) = &self.token_opt {
+                remaining_tokens.push(tok.clone());
+            }
+            remaining_tokens.append(&mut self.tokens.clone());
+
+            self.tokens.clear();
+            self.token_opt = MyOption::Some(Token {
+                token_type: TokenType::EndOfInput,
+                lexeme: String::new(),
+            });
+
+            let command_tokens = if remaining_tokens.len() == 1
+                && remaining_tokens[0].token_type == TokenType::EndOfInput
+            {
+                None
+            } else {
+                Some(remaining_tokens)
+            };
+
+            let command = global::GlobalCommand {
+                line_range: line_range.clone(),
+                pattern,
+                command_tokens,
+                invert,
+            };
+            return Ok(MyOption::Some(Box::new(command)));
         }
         Ok(MyOption::None)
     }
@@ -352,10 +426,10 @@ impl Parser {
     }
 
     fn simple_command(&mut self) -> Result<MyOption<Box<dyn Command>>, GenericError> {
-        let command_opt = self.q_command()? 
-            | self.wq_command()? 
-            | self.q_exclamation_command()? 
-            | self.w_exclamation_command()? 
+        let command_opt = self.q_command()?
+            | self.wq_command()?
+            | self.q_exclamation_command()?
+            | self.w_exclamation_command()?
             | self.w_command()?
             | self.x_command()?
             | self.go_to_line_command()?;
@@ -621,5 +695,28 @@ mod tests {
         assert_eq!(sub.replacement, "CDE");
         assert!(!sub.global);
         assert!(!sub.ignore_case);
+    }
+
+    #[test]
+    fn test_parse_global_delete() {
+        let input = "g/foo/d";
+        let mut parser = Parser::new(input);
+        let command = parser.parse().unwrap();
+        assert!(command.is::<global::GlobalCommand>());
+        let g = command.downcast_ref::<global::GlobalCommand>().unwrap();
+        assert_eq!(g.pattern, "foo");
+        assert!(!g.invert);
+        assert!(g.command_tokens.is_some());
+    }
+
+    #[test]
+    fn test_parse_global_invert() {
+        let input = "g!/bar/p";
+        let mut parser = Parser::new(input);
+        let command = parser.parse().unwrap();
+        assert!(command.is::<global::GlobalCommand>());
+        let g = command.downcast_ref::<global::GlobalCommand>().unwrap();
+        assert_eq!(g.pattern, "bar");
+        assert!(g.invert);
     }
 }

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -194,7 +194,7 @@ impl Parser {
         if self.accept(TokenType::Command, "g") {
             self.pop();
             let mut invert = false;
-            if self.accept(TokenType::Symbol, "!") || self.accept(TokenType::Command, "!") {
+            if self.accept(TokenType::Symbol, "!") {
                 self.pop();
                 invert = true;
             }


### PR DESCRIPTION
## Summary
- add new `GlobalCommand` to execute commands on lines matching a pattern
- extend parser with `global_command` and ability to build from tokens
- support address pattern tokens when parsing
- add lexer and parser tests for `:g` and `:g!`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843b8452bd0832facf9f635fe954a30