### PR TITLE
Add pexpect-based e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,29 @@
+# e2e Tests
+
+This directory contains end-to-end tests for **evi** using `pytest` and the
+`pexpect` library. The tests drive the TUI application through a pseudo
+terminal and verify behaviour described in `doc/spec.md`.
+
+## Setup
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+The tests automatically build the `evi` binary using Cargo before running.
+
+## Running the tests
+
+Execute all e2e tests with:
+
+```bash
+pytest
+```
+
+Specific tests can be selected in the usual `pytest` ways, e.g.:
+
+```bash
+pytest e2e/test_vi_commands.py::test_delete_word
+```

--- a/e2e/helpers.py
+++ b/e2e/helpers.py
@@ -4,19 +4,29 @@ import tempfile
 
 from .conftest import EVI_BIN
 
-def run_commands(commands, initial_content=""):
+
+def run_commands(commands, initial_content="", exit_cmd=":wq\r"):
     fd, path = tempfile.mkstemp()
     try:
-        with os.fdopen(fd, 'w') as f:
+        if initial_content == "":
+            initial_content = "\n"
+        with os.fdopen(fd, "w") as f:
             f.write(initial_content)
+
         env = os.environ.copy()
-        env.setdefault('TERM', 'xterm')
-        child = pexpect.spawn(EVI_BIN, [path], env=env, encoding='utf-8')
+        env.setdefault("TERM", "xterm")
+
+        child = pexpect.spawn(EVI_BIN, [path], env=env, encoding="utf-8")
         child.delaybeforesend = 0.05
+
         for c in commands:
             child.send(c)
-        child.send(':wq\r')
+
+        if exit_cmd is not None:
+            child.send(exit_cmd)
+
         child.expect(pexpect.EOF)
+
         with open(path) as f:
             result = f.read()
     finally:

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,2 @@
+pexpect
+pytest

--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -1,0 +1,51 @@
+from .helpers import run_commands
+
+
+def test_append_after_cursor():
+    result = run_commands(['a', 'b', '\x1b'], initial_content='ac\n')
+    assert result.strip() == 'abc'
+
+
+def test_open_line_above():
+    result = run_commands(['O', 'first', '\x1b'], initial_content='second\n')
+    assert result.splitlines() == ['first', 'second']
+
+
+def test_delete_char():
+    result = run_commands(['l', 'x'], initial_content='abc\n')
+    assert result.strip() == 'ac'
+
+
+def test_delete_word():
+    result = run_commands(['d', 'w'], initial_content='foo bar\n')
+    assert result.strip() == 'bar'
+
+
+def test_search_forward_delete_line():
+    result = run_commands(['/bar\r', 'dd'], initial_content='foo\nbar\nbaz\n')
+    assert result.splitlines() == ['foo', 'baz']
+
+
+def test_search_backward_delete_line():
+    result = run_commands(['j', '?foo\r', 'dd'], initial_content='foo\nbar\nfoo\n')
+    assert result.splitlines() == ['bar', 'foo']
+
+
+def test_undo():
+    result = run_commands(['x', 'u'], initial_content='hello\n')
+    assert result.strip() == 'hello'
+
+
+def test_write_quit_ZZ():
+    result = run_commands(['i', 'done', '\x1b', 'ZZ'], exit_cmd=None)
+    assert result.strip() == 'done'
+
+
+def test_cursor_motion_zero_dollar():
+    result = run_commands(['$', 'x', 'u', '0', 'x'], initial_content='abc\n')
+    assert result.strip() == 'bc'
+
+
+def test_word_motion_w_b():
+    result = run_commands(['w', 'x', 'b', 'x'], initial_content='one two\n')
+    assert result.strip() == 'ne wo'


### PR DESCRIPTION
## Summary
- add helper ability to customise exit command and initialise empty files
- add new vi command test suite covering cursor motion, edits and search
- document e2e testing usage and add requirements.txt

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843db20d3ec832f965d5172a922142b