### PR TITLE
Add e2e tests to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,12 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install e2e test requirements
+      run: pip install -r e2e/requirements.txt
+    - name: Build evi for e2e tests
+      run: cargo build --verbose
+    - name: Run e2e tests
+      run: pytest e2e --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,5 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install e2e test requirements
       run: pip install -r e2e/requirements.txt
-    - name: Build evi for e2e tests
-      run: cargo build --verbose
     - name: Run e2e tests
       run: pytest e2e --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - name: Cache Python dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/e2e/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install e2e test requirements
       run: pip install -r e2e/requirements.txt
     - name: Build evi for e2e tests


### PR DESCRIPTION
## Summary
- run Python-based e2e tests in CI

## Testing
- `cargo test`
- `pytest e2e`

------
https://chatgpt.com/codex/tasks/task_e_6843df645054832f912b94a0959312a9