### PR TITLE
Add undo/redo for line copy and move

### DIFF
--- a/src/command/commands/copy_lines.rs
+++ b/src/command/commands/copy_lines.rs
@@ -86,10 +86,9 @@ impl Command for CopyLines {
 
     fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
         if let Some(idx) = self.insertion_idx {
-            if idx + self.copied_len <= editor.buffer.lines.len() {
-                editor.buffer.lines.drain(idx..idx+self.copied_len);
-            }
-        }
+            if idx < editor.buffer.lines.len() {
+                let end = (idx + self.copied_len).min(editor.buffer.lines.len());
+                editor.buffer.lines.drain(idx..end);
         Ok(())
     }
 

--- a/src/command/commands/copy_lines.rs
+++ b/src/command/commands/copy_lines.rs
@@ -89,6 +89,8 @@ impl Command for CopyLines {
             if idx < editor.buffer.lines.len() {
                 let end = (idx + self.copied_len).min(editor.buffer.lines.len());
                 editor.buffer.lines.drain(idx..end);
+            }
+        }
         Ok(())
     }
 

--- a/src/command/commands/copy_lines.rs
+++ b/src/command/commands/copy_lines.rs
@@ -86,10 +86,8 @@ impl Command for CopyLines {
 
     fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
         if let Some(idx) = self.insertion_idx {
-            for _ in 0..self.copied_len {
-                if idx < editor.buffer.lines.len() {
-                    editor.buffer.lines.remove(idx);
-                }
+            if idx + self.copied_len <= editor.buffer.lines.len() {
+                editor.buffer.lines.drain(idx..idx+self.copied_len);
             }
         }
         Ok(())

--- a/src/command/commands/delete.rs
+++ b/src/command/commands/delete.rs
@@ -173,6 +173,10 @@ pub struct DeleteLines {
 }
 
 impl Command for DeleteLines {
+    fn is_undoable(&self) -> bool {
+        true
+    }
+
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
         let start_address = self.line_range.start.clone();
         let end_address = self.line_range.end.clone();

--- a/src/command/commands/delete.rs
+++ b/src/command/commands/delete.rs
@@ -210,8 +210,10 @@ impl Command for DeleteLines {
             if let Some(text) = &self.text {
                 let row = editor_cursor_data.cursor_position_in_buffer.row;
                 let col = editor_cursor_data.cursor_position_in_buffer.col;
-                editor.buffer.insert(row, col, text)?;
-                editor.restore_cursor_data(*editor_cursor_data);
+                if row < editor.buffer.lines.len() {
+                    editor.buffer.insert(row, col, text)?;
+                    editor.restore_cursor_data(*editor_cursor_data);
+                }
             }
         }
         Ok(())

--- a/src/command/commands/delete.rs
+++ b/src/command/commands/delete.rs
@@ -211,9 +211,20 @@ impl Command for DeleteLines {
                 let row = editor_cursor_data.cursor_position_in_buffer.row;
                 let col = editor_cursor_data.cursor_position_in_buffer.col;
                 editor.buffer.insert(row, col, text)?;
+                editor.restore_cursor_data(*editor_cursor_data);
             }
         }
         Ok(())
+    }
+
+    fn redo(&mut self, editor: &mut Editor) -> GenericResult<Option<Box<dyn Command>>> {
+        let mut new_cmd = Box::new(DeleteLines {
+            editor_cursor_data: None,
+            line_range: self.line_range.clone(),
+            text: None,
+        });
+        new_cmd.execute(editor)?;
+        Ok(Some(new_cmd))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/command/commands/move_lines.rs
+++ b/src/command/commands/move_lines.rs
@@ -65,15 +65,11 @@ impl Command for MoveLines {
 
     fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
         if let (Some(base), Some(start_idx)) = (self.inserted_base, self.original_start_idx) {
-            for _ in 0..self.drained_lines.len() {
-                if base < editor.buffer.lines.len() {
-                    editor.buffer.lines.remove(base);
-                }
+            if base < editor.buffer.lines.len() {
+                let remove_end = std::cmp::min(base + self.drained_lines.len(), editor.buffer.lines.len());
+                editor.buffer.lines.drain(base..remove_end);
             }
-            editor
-                .buffer
-                .lines
-                .splice(start_idx..start_idx, self.drained_lines.clone().into_iter());
+            editor.buffer.lines.splice(start_idx..start_idx, self.drained_lines.clone().into_iter());
         }
         Ok(())
     }

--- a/src/command/commands/move_lines.rs
+++ b/src/command/commands/move_lines.rs
@@ -9,9 +9,16 @@ use crate::generic_error::GenericResult;
 pub struct MoveLines {
     pub line_range: LineRange,
     pub address: LineAddressType,
+    pub original_start_idx: Option<usize>,
+    pub inserted_base: Option<usize>,
+    pub drained_lines: Vec<String>,
 }
 
 impl Command for MoveLines {
+    fn is_undoable(&self) -> bool {
+        true
+    }
+
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
         let len = editor.buffer.lines.len();
         let mut start = editor.get_line_number_from(&self.line_range.start);
@@ -30,6 +37,8 @@ impl Command for MoveLines {
         let mut dest = editor.get_line_number_from(&self.address);
 
         let lines: Vec<String> = editor.buffer.lines.drain(start..=end).collect();
+        self.original_start_idx = Some(start);
+        self.drained_lines = lines.clone();
         if dest > end {
             dest -= lines.len();
         }
@@ -49,11 +58,36 @@ impl Command for MoveLines {
             dest + 1
         };
 
-        editor
-            .buffer
-            .lines
-            .splice(base..base, lines.into_iter());
+        editor.buffer.lines.splice(base..base, lines.into_iter());
+        self.inserted_base = Some(base);
         Ok(())
+    }
+
+    fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        if let (Some(base), Some(start_idx)) = (self.inserted_base, self.original_start_idx) {
+            for _ in 0..self.drained_lines.len() {
+                if base < editor.buffer.lines.len() {
+                    editor.buffer.lines.remove(base);
+                }
+            }
+            editor
+                .buffer
+                .lines
+                .splice(start_idx..start_idx, self.drained_lines.clone().into_iter());
+        }
+        Ok(())
+    }
+
+    fn redo(&mut self, editor: &mut Editor) -> GenericResult<Option<Box<dyn Command>>> {
+        let mut new_cmd = Box::new(MoveLines {
+            line_range: self.line_range.clone(),
+            address: self.address.clone(),
+            original_start_idx: None,
+            inserted_base: None,
+            drained_lines: Vec::new(),
+        });
+        new_cmd.execute(editor)?;
+        Ok(Some(new_cmd))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/command/commands/move_lines.rs
+++ b/src/command/commands/move_lines.rs
@@ -66,10 +66,14 @@ impl Command for MoveLines {
     fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
         if let (Some(base), Some(start_idx)) = (self.inserted_base, self.original_start_idx) {
             if base < editor.buffer.lines.len() {
-                let remove_end = std::cmp::min(base + self.drained_lines.len(), editor.buffer.lines.len());
-                editor.buffer.lines.drain(base..remove_end);
+                let end = (base + self.drained_lines.len()).min(editor.buffer.lines.len());
+                editor.buffer.lines.drain(base..end);
             }
-            editor.buffer.lines.splice(start_idx..start_idx, self.drained_lines.clone().into_iter());
+            let insert_idx = start_idx.min(editor.buffer.lines.len());
+            editor
+                .buffer
+                .lines
+                .splice(insert_idx..insert_idx, self.drained_lines.clone().into_iter());
         }
         Ok(())
     }

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -204,11 +204,13 @@ impl Parser {
         line_range: &LineRange,
     ) -> Result<MyOption<Box<dyn Command>>, GenericError> {
         if self.accept(TokenType::Command, "m") {
-            self.pop();
             let address = self.destination_address()?;
             let mv = move_lines::MoveLines {
                 line_range: line_range.clone(),
                 address,
+                original_start_idx: None,
+                inserted_base: None,
+                drained_lines: Vec::new(),
             };
             return Ok(MyOption::Some(Box::new(mv)));
         }
@@ -220,9 +222,9 @@ impl Parser {
         line_range: &LineRange,
     ) -> Result<MyOption<Box<dyn Command>>, GenericError> {
         if self.accept(TokenType::Command, "co") {
-            self.pop();
+            // accepted 'co'
         } else if self.accept(TokenType::Command, "t") {
-            self.pop();
+            // accepted 't'
         } else {
             return Ok(MyOption::None);
         }
@@ -230,6 +232,8 @@ impl Parser {
         let cp = copy_lines::CopyLines {
             line_range: line_range.clone(),
             address,
+            insertion_idx: None,
+            copied_len: 0,
         };
         return Ok(MyOption::Some(Box::new(cp)));
     }


### PR DESCRIPTION
## Summary
- implement undo/redo functionality for the `CopyLines` command
- implement undo/redo functionality for the `MoveLines` command
- mark `DeleteLines` as undoable
- simplify parsing of copy and move commands and default new fields

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_6843f7edee38832f89de7cb51a84c33d