### PR TITLE
Improve pexpect interaction in e2e helpers

### DIFF
--- a/e2e/helpers.py
+++ b/e2e/helpers.py
@@ -36,10 +36,12 @@ def run_commands(commands, initial_content="", exit_cmd=":wq\r"):
         child.delaybeforesend = float(os.getenv("EVI_DELAY_BEFORE_SEND", "0.1"))
 
         for c in commands:
-            child.send(c)
+            for ch in c:
+                child.send(ch)
 
         if exit_cmd is not None:
-            child.send(exit_cmd)
+            for ch in exit_cmd:
+                child.send(ch)
 
         child.expect(pexpect.EOF)
 


### PR DESCRIPTION
## Summary
- split strings into individual characters when sending input to `evi`

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68440570f130832f91b7fbd8d64f6ecf