### PR TITLE
Add Docker-based e2e testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: e2e-docker
+
+e2e-docker:
+	scripts/e2e_docker.sh

--- a/docker/e2e.Dockerfile
+++ b/docker/e2e.Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+# Install dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        curl \
+        git \
+        build-essential \
+        python3 \
+        python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install Python requirements for e2e tests
+COPY e2e/requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+WORKDIR /evi
+
+ENTRYPOINT cargo build --verbose && pytest e2e --verbose

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -27,3 +27,13 @@ Specific tests can be selected in the usual `pytest` ways, e.g.:
 ```bash
 pytest e2e/test_vi_commands.py::test_delete_word
 ```
+
+## Running the tests in Docker
+
+The repository provides a Docker setup for running the e2e tests in an isolated environment. Build the image and execute the tests using:
+
+```bash
+scripts/e2e_docker.sh
+```
+
+This script mounts the project directory into the container and runs `cargo build --verbose` followed by `pytest e2e --verbose`.

--- a/scripts/e2e_docker.sh
+++ b/scripts/e2e_docker.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Build Docker image
+docker build -f "$REPO_DIR/docker/e2e.Dockerfile" -t evi-e2e "$REPO_DIR"
+
+# Run tests inside container
+docker run --rm -it -v "$REPO_DIR":/evi evi-e2e


### PR DESCRIPTION
## Summary
- add `docker/e2e.Dockerfile` to run Cargo and pytest in a container
- add `scripts/e2e_docker.sh` helper to build and run the Docker image
- mention Docker workflow in `e2e/README.md`
- provide a Makefile target `e2e-docker` for convenience

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_684413bacb3c832fb057f793bd8c3c3b