### PR TITLE
Fix replace-char mode and remove build warnings

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -327,6 +327,7 @@ impl Editor {
     }
 
     pub fn set_replace_char_mode_with_count(&mut self, count: usize) {
+        self.set_replace_char_mode();
         self.pending_replace_char_count = count;
     }
 


### PR DESCRIPTION
## Summary
- ensure `ReplaceChar` mode is entered when using `set_replace_char_mode_with_count`

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68441c7630f4832f916fa9ab97a4dbdd