### PR TITLE
Implement repeat command and tests

### DIFF
--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -36,6 +36,16 @@ def test_undo():
     assert result.strip() == 'hello'
 
 
+def test_repeat_command():
+    result = run_commands(['x', '.', '.'], initial_content='abc\n')
+    assert result.strip() == ''
+
+
+def test_undo_then_repeat():
+    result = run_commands(['x', 'u', '.'], initial_content='abc\n')
+    assert result.strip() == 'bc'
+
+
 def test_write_quit_ZZ():
     result = run_commands(['i', 'done', '\x1b', 'ZZ'], exit_cmd=None)
     assert result.strip() == 'done'

--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -46,6 +46,21 @@ def test_undo_then_repeat():
     assert result.strip() == 'bc'
 
 
+def test_repeat_delete_char_with_count():
+    result = run_commands(['3', 'x', '.'], initial_content='abcdef\n')
+    assert result.strip() == ''
+
+
+def test_repeat_insert():
+    result = run_commands(['i', 'abc', '\x1b', '.'], initial_content='')
+    assert result.strip() == 'abcabc'
+
+
+def test_repeat_delete_word():
+    result = run_commands(['d', 'w', '.'], initial_content='one two three\n')
+    assert result.strip() == 'three'
+
+
 def test_write_quit_ZZ():
     result = run_commands(['i', 'done', '\x1b', 'ZZ'], exit_cmd=None)
     assert result.strip() == 'done'

--- a/src/command/base.rs
+++ b/src/command/base.rs
@@ -24,6 +24,7 @@ impl Clone for Box<dyn Command> {
 }
 
 pub trait Command: CommandClone {
+    // Executes the command, performing the primary action.
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()>;
 
     fn is_reusable(&self) -> bool {

--- a/src/command/base.rs
+++ b/src/command/base.rs
@@ -4,7 +4,26 @@ use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::{editor::Editor, generic_error::GenericResult};
 
-pub trait Command {
+pub trait CommandClone {
+    fn clone_box(&self) -> Box<dyn Command>;
+}
+
+impl<T> CommandClone for T
+where
+    T: 'static + Command + Clone,
+{
+    fn clone_box(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Command> {
+    fn clone(&self) -> Box<dyn Command> {
+        self.as_ref().clone_box()
+    }
+}
+
+pub trait Command: CommandClone {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()>;
 
     fn is_reusable(&self) -> bool {
@@ -65,6 +84,7 @@ pub struct CommandData {
     pub range: Option<JumpCommandData>,
 }
 
+#[derive(Clone)]
 pub struct ExecutedCommand {
     pub command_data: CommandData,
     pub command: Box<dyn Command>,

--- a/src/command/commands/copy_lines.rs
+++ b/src/command/commands/copy_lines.rs
@@ -6,6 +6,7 @@ use crate::data::{LineAddressType, LineRange, SimpleLineAddressType};
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct CopyLines {
     pub line_range: LineRange,
     pub address: LineAddressType,

--- a/src/command/commands/delete.rs
+++ b/src/command/commands/delete.rs
@@ -166,6 +166,7 @@ impl Command for Delete {
     }
 }
 
+#[derive(Clone)]
 pub struct DeleteLines {
     pub editor_cursor_data: Option<crate::editor::EditorCursorData>,
     pub line_range: crate::data::LineRange,

--- a/src/command/commands/delete.rs
+++ b/src/command/commands/delete.rs
@@ -161,6 +161,16 @@ impl Command for Delete {
         Ok(())
     }
 
+    fn redo(&mut self, editor: &mut Editor) -> GenericResult<Option<Box<dyn Command>>> {
+        let mut new_cmd = Box::new(Delete {
+            editor_cursor_data: None,
+            text: None,
+            jump_command_data_opt: self.jump_command_data_opt,
+        });
+        new_cmd.execute(editor)?;
+        Ok(Some(new_cmd))
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/command/commands/esc.rs
+++ b/src/command/commands/esc.rs
@@ -4,6 +4,7 @@ use crate::command::base::Command;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct Esc;
 impl Command for Esc {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {

--- a/src/command/commands/exit.rs
+++ b/src/command/commands/exit.rs
@@ -4,6 +4,7 @@ use crate::command::base::Command;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct ExitCommand;
 impl Command for ExitCommand {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -22,6 +23,7 @@ impl Command for ExitCommand {
     }
 }
 
+#[derive(Clone)]
 pub struct ExitWithSaveCommand;
 impl Command for ExitWithSaveCommand {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -38,6 +40,7 @@ impl Command for ExitWithSaveCommand {
     }
 }
 
+#[derive(Clone)]
 pub struct ExitWithoutSaveCommand;
 impl Command for ExitWithoutSaveCommand {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {

--- a/src/command/commands/find_char.rs
+++ b/src/command/commands/find_char.rs
@@ -30,6 +30,7 @@ impl Command for FindChar {
     }
 }
 
+#[derive(Clone)]
 pub struct RepeatFindChar;
 
 impl Command for RepeatFindChar {

--- a/src/command/commands/global.rs
+++ b/src/command/commands/global.rs
@@ -8,6 +8,7 @@ use crate::editor::Editor;
 use crate::ex::parser::Parser;
 use crate::generic_error::{GenericError, GenericResult};
 
+#[derive(Clone)]
 pub struct GlobalCommand {
     pub line_range: LineRange,
     pub pattern: String,

--- a/src/command/commands/go_to_line.rs
+++ b/src/command/commands/go_to_line.rs
@@ -6,8 +6,9 @@ use crate::data::LineAddressType;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct GoToLineCommand {
-    pub line_address: LineAddressType
+    pub line_address: LineAddressType,
 }
 
 impl Command for GoToLineCommand {

--- a/src/command/commands/misc.rs
+++ b/src/command/commands/misc.rs
@@ -6,6 +6,7 @@ use crate::generic_error::GenericResult;
 
 // File
 // Historical versions of the ex editor file command displayed a current line and number of lines in the edit buffer of 0 when the file was empty, while the vi <control>-G command displayed a current line and number of lines in the edit buffer of 1 in the same situation. POSIX.1-2017 does not permit this discrepancy, instead requiring that a message be displayed indicating that the file is empty.
+#[derive(Clone)]
 pub struct DisplayFile;
 impl Command for DisplayFile {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod paste;
 pub mod print;
 pub mod replace;
 pub mod replace_char;
+pub mod repeat;
 pub mod search;
 pub mod substitute;
 pub mod undo;

--- a/src/command/commands/move_cursor.rs
+++ b/src/command/commands/move_cursor.rs
@@ -5,6 +5,7 @@ use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 use crate::util::get_char_width;
 
+#[derive(Clone)]
 pub struct ForwardChar;
 impl Command for ForwardChar {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -36,6 +37,7 @@ impl Command for ForwardChar {
     }
 }
 
+#[derive(Clone)]
 pub struct BackwardChar;
 impl Command for BackwardChar {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -66,6 +68,7 @@ impl Command for BackwardChar {
     }
 }
 
+#[derive(Clone)]
 pub struct MoveBeginningOfLine;
 impl Command for MoveBeginningOfLine {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -81,6 +84,7 @@ impl Command for MoveBeginningOfLine {
     }
 }
 
+#[derive(Clone)]
 pub struct MoveEndOfLine;
 impl Command for MoveEndOfLine {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -98,6 +102,7 @@ impl Command for MoveEndOfLine {
     }
 }
 
+#[derive(Clone)]
 pub struct NextLine;
 impl Command for NextLine {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -137,6 +142,7 @@ impl Command for NextLine {
     }
 }
 
+#[derive(Clone)]
 pub struct PreviousLine;
 impl Command for PreviousLine {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -180,6 +186,7 @@ impl Command for PreviousLine {
     }
 }
 
+#[derive(Clone)]
 pub struct ForwardWord;
 impl Command for ForwardWord {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
@@ -227,6 +234,7 @@ impl Command for ForwardWord {
     }
 }
 
+#[derive(Clone)]
 pub struct BackwardWord;
 impl Command for BackwardWord {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {

--- a/src/command/commands/move_lines.rs
+++ b/src/command/commands/move_lines.rs
@@ -6,6 +6,7 @@ use crate::data::{LineAddressType, LineRange, SimpleLineAddressType};
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct MoveLines {
     pub line_range: LineRange,
     pub address: LineAddressType,
@@ -70,10 +71,10 @@ impl Command for MoveLines {
                 editor.buffer.lines.drain(base..end);
             }
             let insert_idx = start_idx.min(editor.buffer.lines.len());
-            editor
-                .buffer
-                .lines
-                .splice(insert_idx..insert_idx, self.drained_lines.clone().into_iter());
+            editor.buffer.lines.splice(
+                insert_idx..insert_idx,
+                self.drained_lines.clone().into_iter(),
+            );
         }
         Ok(())
     }

--- a/src/command/commands/print.rs
+++ b/src/command/commands/print.rs
@@ -5,9 +5,10 @@ use crate::data::LineRange;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct PrintCommand {
     #[cfg_attr(not(test), allow(dead_code))]
-    pub line_range: LineRange
+    pub line_range: LineRange,
 }
 
 impl Command for PrintCommand {

--- a/src/command/commands/repeat.rs
+++ b/src/command/commands/repeat.rs
@@ -5,12 +5,11 @@ use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
 #[derive(Clone)]
-pub struct NoOpCommand;
+pub struct Repeat;
 
-impl Command for NoOpCommand {
-    fn execute(&mut self, _editor: &mut Editor) -> GenericResult<()> {
-        // 何もしない
-        Ok(())
+impl Command for Repeat {
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.repeat_last_command()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/command/commands/search.rs
+++ b/src/command/commands/search.rs
@@ -4,6 +4,7 @@ use crate::command::base::Command;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct RepeatSearch {
     pub same_direction: bool,
 }

--- a/src/command/commands/substitute.rs
+++ b/src/command/commands/substitute.rs
@@ -7,6 +7,7 @@ use crate::data::LineRange;
 use crate::editor::Editor;
 use crate::generic_error::{GenericError, GenericResult};
 
+#[derive(Clone)]
 pub struct SubstituteCommand {
     pub line_range: LineRange,
     pub pattern: String,
@@ -45,4 +46,3 @@ impl Command for SubstituteCommand {
         self
     }
 }
-

--- a/src/command/commands/undo.rs
+++ b/src/command/commands/undo.rs
@@ -4,6 +4,7 @@ use crate::command::base::Command;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
+#[derive(Clone)]
 pub struct Undo;
 impl Command for Undo {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {

--- a/src/command/commands/write.rs
+++ b/src/command/commands/write.rs
@@ -4,7 +4,7 @@ use crate::command::base::Command;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct WriteCommand {
     #[cfg_attr(not(test), allow(dead_code))]
     pub force: bool,

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -208,6 +208,11 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             ..
         } => Box::new(Undo {}),
 
+        CommandData {
+            key_code: KeyCode::Char('.'),
+            ..
+        } => Box::new(super::commands::repeat::Repeat {}),
+
         // Control + g
         CommandData {
             key_code: KeyCode::Char('g'),

--- a/src/command/key_codes.rs
+++ b/src/command/key_codes.rs
@@ -22,6 +22,8 @@ pub fn is_editing_command_without_range(key: &KeyCode) -> bool {
         Char('i') | Char('I') | Char('a') | Char('A') => true,
         Char('o') | Char('O') | Char('s') | Char('S') => true,
         Char('x') | Char('X') | Char('r') | Char('R') => true,
+        // '.' repeats the last command which may originate from any category,
+        // but it is parsed as a standalone editing command without a range.
         Char('D') | Char('p') | Char('P') | Char('~') | Char('.') => true,
         Char('u') => true,
         _ => false,

--- a/src/command/key_codes.rs
+++ b/src/command/key_codes.rs
@@ -22,7 +22,7 @@ pub fn is_editing_command_without_range(key: &KeyCode) -> bool {
         Char('i') | Char('I') | Char('a') | Char('A') => true,
         Char('o') | Char('O') | Char('s') | Char('S') => true,
         Char('x') | Char('X') | Char('r') | Char('R') => true,
-        Char('D') | Char('p') | Char('P') | Char('~') => true,
+        Char('D') | Char('p') | Char('P') | Char('~') | Char('.') => true,
         Char('u') => true,
         _ => false,
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -664,11 +664,14 @@ impl Editor {
         if let Some(last_chunk) = self.last_command.clone() {
             let mut new_chunk: Vec<ExecutedCommand> = Vec::new();
             for executed_command in last_chunk.into_iter() {
-                let mut command = executed_command.command;
-                command.redo(self)?;
+                let mut command_to_act_on = executed_command.command;
+                let command_for_next_repeat = match command_to_act_on.redo(self)? {
+                    Some(next_command_state) => next_command_state,
+                    None => command_to_act_on, 
+                };
                 new_chunk.push(ExecutedCommand {
                     command_data: executed_command.command_data,
-                    command,
+                    command: command_for_next_repeat,
                 });
             }
             if !new_chunk.is_empty() {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -90,6 +90,7 @@ pub struct Editor {
     pub window_position_in_buffer: CursorPositionInBuffer,
     pub status_line: String,
     pub command_history: Vec<Vec<ExecutedCommand>>,
+    pub last_command: Option<Vec<ExecutedCommand>>,
     pub unnamed_register: String,
     pub unnamed_register_linewise: bool,
     pub last_input_string: String,
@@ -119,6 +120,7 @@ impl Editor {
             window_position_in_buffer: CursorPositionInBuffer { row: 0, col: 0 },
             status_line: "".to_string(),
             command_history: Vec::new(),
+            last_command: None,
             unnamed_register: String::new(),
             unnamed_register_linewise: false,
             last_input_string: "".to_string(),
@@ -215,7 +217,9 @@ impl Editor {
 
             let count = last_executed_command.command_data.count;
             if count == 1 {
-                self.command_history.push(vec![last_executed_command]);
+                let chunk = vec![last_executed_command];
+                self.last_command = Some(chunk.clone());
+                self.command_history.push(chunk);
             } else if count >= 2 {
                 last_executed_command.command_data.count = 1;
                 let command_data: CommandData = last_executed_command.command_data.clone();
@@ -224,6 +228,9 @@ impl Editor {
                     command_data,
                     Some(last_executed_command.command),
                 );
+                if let Some(last) = self.command_history.last() {
+                    self.last_command = Some(last.clone());
+                }
             } else {
                 panic!("count: {}", count);
             }
@@ -262,6 +269,7 @@ impl Editor {
             info!("command_series.len(): {}", command_series.len());
         }
         info!("### command_series.len(): {}", command_series.len());
+        self.last_command = Some(command_series.clone());
         self.command_history.push(command_series);
     }
 
@@ -413,10 +421,12 @@ impl Editor {
             modifiers: crossterm::event::KeyModifiers::NONE,
             range: None,
         };
-        self.command_history.push(vec![ExecutedCommand {
+        let chunk = vec![ExecutedCommand {
             command_data,
             command,
-        }]);
+        }];
+        self.last_command = Some(chunk.clone());
+        self.command_history.push(chunk);
         self.ex_command_data = "".to_string();
         Ok(())
     }
@@ -599,10 +609,12 @@ impl Editor {
                 command.execute(self)?;
             }
             if command.is_undoable() {
-                self.command_history.push(vec![ExecutedCommand {
+                let chunk = vec![ExecutedCommand {
                     command_data,
                     command,
-                }]);
+                }];
+                self.last_command = Some(chunk.clone());
+                self.command_history.push(chunk);
             }
         } else if !command.is_modeful() && !command.is_reusable() {
             let mut command_chunk: Vec<ExecutedCommand> = Vec::new();
@@ -621,15 +633,18 @@ impl Editor {
                 }
             }
             if command_chunk.len() > 0 {
+                self.last_command = Some(command_chunk.clone());
                 self.command_history.push(command_chunk);
             }
         } else {
             command.execute(self)?;
             if command.is_undoable() {
-                self.command_history.push(vec![ExecutedCommand {
+                let chunk = vec![ExecutedCommand {
                     command_data,
                     command,
-                }]);
+                }];
+                self.last_command = Some(chunk.clone());
+                self.command_history.push(chunk);
             }
         }
         Ok(())
@@ -646,6 +661,24 @@ impl Editor {
         } else {
             Ok(())
         }
+    }
+
+    pub fn repeat_last_command(&mut self) -> GenericResult<()> {
+        if let Some(last_chunk) = self.last_command.clone() {
+            let mut new_chunk: Vec<ExecutedCommand> = Vec::new();
+            for mut executed_command in last_chunk.into_iter() {
+                let redo_result = executed_command.command.redo(self)?;
+                new_chunk.push(ExecutedCommand {
+                    command_data: executed_command.command_data,
+                    command: redo_result.unwrap_or(executed_command.command),
+                });
+            }
+            if !new_chunk.is_empty() {
+                self.last_command = Some(new_chunk.clone());
+                self.command_history.push(new_chunk);
+            }
+        }
+        Ok(())
     }
 
     pub fn render(self: &mut Editor, stdout: &mut std::io::Stdout) -> GenericResult<()> {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -664,23 +664,12 @@ impl Editor {
         if let Some(last_chunk) = self.last_command.clone() {
             let mut new_chunk: Vec<ExecutedCommand> = Vec::new();
             for executed_command in last_chunk.into_iter() {
-                let mut command_opt = Some(executed_command.command);
-                let disassemble_data = CommandData {
-                    count: 1,
-                    ..executed_command.command_data
-                };
-                for _ in 0..executed_command.command_data.count {
-                    if let Some(mut command) = command_opt {
-                        let redo_result = command.redo(self)?;
-                        new_chunk.push(ExecutedCommand {
-                            command_data: disassemble_data,
-                            command,
-                        });
-                        command_opt = redo_result;
-                    } else {
-                        break;
-                    }
-                }
+                let mut command = executed_command.command;
+                command.redo(self)?;
+                new_chunk.push(ExecutedCommand {
+                    command_data: executed_command.command_data,
+                    command,
+                });
             }
             if !new_chunk.is_empty() {
                 self.last_command = Some(new_chunk.clone());


### PR DESCRIPTION
## Summary
- add `Repeat` command triggered by `.`
- track last executed command in editor and implement `repeat_last_command`
- support cloning commands for history and repeat
- extend key codes and command factory for `.`
- add e2e tests for repeat behaviour

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68441e8327f8832f9057bd12a8de10dd