### PR TITLE
Implement ex command line editing

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -73,9 +73,35 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.set_command_mode();
                             editor.status_line = "".to_string();
                         }
-                        _ => {
-                            editor.append_ex_command(key_data);
+                        KeyData {
+                            key_code: event::KeyCode::Backspace,
+                            ..
                         }
+                        | KeyData {
+                            key_code: event::KeyCode::Char('h'),
+                            modifiers: KeyModifiers::CONTROL,
+                        } => {
+                            editor.backspace_ex_command();
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Left,
+                            ..
+                        } => {
+                            editor.move_ex_command_cursor_left();
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Right,
+                            ..
+                        } => {
+                            editor.move_ex_command_cursor_right();
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Char(c),
+                            ..
+                        } => {
+                            editor.insert_ex_command_char(c);
+                        }
+                        _ => {}
                     }
                 } else if editor.is_search_mode() {
                     let key_data: KeyData = key_event.into();

--- a/src/render.rs
+++ b/src/render.rs
@@ -79,10 +79,15 @@ pub fn render(editor: &mut Editor, stdout: &mut std::io::Stdout) -> GenericResul
         stdout.queue(style::Print(" "))?;
     }
 
-    stdout.queue(cursor::MoveTo(
-        editor.cursor_position_on_screen.col as u16,
-        editor.cursor_position_on_screen.row as u16,
-    ))?;
+    let (cursor_col, cursor_row) = if editor.is_ex_command_mode() {
+        (editor.get_ex_command_cursor_col(), editor.content_height())
+    } else {
+        (
+            editor.cursor_position_on_screen.col as u16,
+            editor.cursor_position_on_screen.row as u16,
+        )
+    };
+    stdout.queue(cursor::MoveTo(cursor_col, cursor_row))?;
     stdout.flush()?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- add cursor tracking for ex command entry
- support editing the ex command line (arrow keys and backspace)
- render cursor at the command line when in ex mode

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose` *(fails: test_motion_dollar, test_motion_l)*

------
https://chatgpt.com/codex/tasks/task_e_6844dac4c298832f8e871ede785b7ccd