### PR TITLE
Add ex command history navigation

### DIFF
--- a/e2e/test_ex_history.py
+++ b/e2e/test_ex_history.py
@@ -1,0 +1,15 @@
+from .helpers import run_commands
+
+
+def test_ex_history_navigation():
+    commands = [
+        ':2d\r',
+        ':1d\r',
+        ':',
+        '\x1b[A',
+        '\x1b[A',
+        '\x1b[B',
+        '\r',
+    ]
+    result = run_commands(commands, initial_content='1\n2\n3\n4\n')
+    assert result.splitlines() == ['4']

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -96,6 +96,18 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.move_ex_command_cursor_right();
                         }
                         KeyData {
+                            key_code: event::KeyCode::Up,
+                            ..
+                        } => {
+                            editor.previous_ex_command();
+                        }
+                        KeyData {
+                            key_code: event::KeyCode::Down,
+                            ..
+                        } => {
+                            editor.next_ex_command();
+                        }
+                        KeyData {
                             key_code: event::KeyCode::Char(c),
                             ..
                         } => {


### PR DESCRIPTION
## Summary
- support navigating previous/next Ex commands with up/down keys
- preserve current Ex command while browsing history
- test Ex command history navigation

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose` *(fails: test_motion_w, test_motion_l, test_cursor_j_k_on_wrapped_line)*

------
https://chatgpt.com/codex/tasks/task_e_6844ec07a598832fa667467754bb4996