### PR TITLE
Implement page up/down commands

### DIFF
--- a/e2e/test_motion_commands.py
+++ b/e2e/test_motion_commands.py
@@ -158,3 +158,23 @@ def test_motion_G():
 #         command_to_test="\x02",  # Ctrl-B page up
 #         expected_cursor_pos=(1, 1),
 #     )
+
+
+def test_motion_ctrl_f():
+    run_motion_test(
+        file_content="line1\nline2\nline3\nline4\nline5\nline6\n",
+        terminal_size=(4, 20),
+        initial_cursor_pos=(1, 1),
+        command_to_test="\x1b[6~",
+        expected_cursor_pos=(1, 1),
+    )
+
+
+def test_motion_ctrl_b():
+    run_motion_test(
+        file_content="one\ntwo\nthree\nfour\nfive\nsix\n",
+        terminal_size=(4, 20),
+        initial_cursor_pos=(4, 1),
+        command_to_test="\x1b[5~",
+        expected_cursor_pos=(1, 1),
+    )

--- a/src/command/commands/move_cursor.rs
+++ b/src/command/commands/move_cursor.rs
@@ -288,3 +288,27 @@ impl Command for BackwardWord {
         self
     }
 }
+
+#[derive(Clone)]
+pub struct PageDown;
+impl Command for PageDown {
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.page_down()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct PageUp;
+impl Command for PageUp {
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        editor.page_up()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -59,6 +59,26 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             ..
         } => Box::new(MoveEndOfLine {}),
 
+        // page movement commands
+        CommandData {
+            key_code: KeyCode::Char('f'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        } => Box::new(PageDown {}),
+        CommandData {
+            key_code: KeyCode::Char('b'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        } => Box::new(PageUp {}),
+        CommandData {
+            key_code: KeyCode::PageDown,
+            ..
+        } => Box::new(PageDown {}),
+        CommandData {
+            key_code: KeyCode::PageUp,
+            ..
+        } => Box::new(PageUp {}),
+
         // jump commands
         CommandData {
             key_code: KeyCode::Char('w'),

--- a/src/command/key_codes.rs
+++ b/src/command/key_codes.rs
@@ -13,6 +13,7 @@ pub fn is_jump_command(key: &KeyCode) -> bool {
         Char(';') | Char(',') | Char(')') | Char('(') => true,
         Char('}') | Char('{') | Char(']') | Char('[') => true,
         Char('%') | Char('n') | Char('N') => true,
+        KeyCode::PageDown | KeyCode::PageUp => true,
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary
- add `page_down` and `page_up` helpers to `Editor`
- create `PageDown` and `PageUp` commands
- wire page movement commands in command factory and key map
- allow PageUp/PageDown keys in key parser
- test the new commands in motion e2e suite

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6844f0532010832f9034b5ae984966b2