### PR TITLE
Fix G command preserves column

### DIFF
--- a/src/command/commands/go_to_file.rs
+++ b/src/command/commands/go_to_file.rs
@@ -56,7 +56,7 @@ impl Command for GoToLastLine {
             .buffer
             .lines
             .get(target)
-            .map(|line| line.chars().count().min(current_col))
+            .map(|line| line.chars().count().saturating_sub(1).min(current_col))
             .unwrap_or(0);
         editor.move_cursor_to(target, dest_col)?;
         Ok(())

--- a/src/command/commands/go_to_file.rs
+++ b/src/command/commands/go_to_file.rs
@@ -23,7 +23,7 @@ impl Command for GoToFirstLine {
             .buffer
             .lines
             .get(target)
-            .map(|line| line.chars().count().min(current_col))
+            .map(|line| line.chars().count().saturating_sub(1).min(current_col))
             .unwrap_or(0);
         editor.move_cursor_to(target, dest_col)?;
         Ok(())

--- a/src/command/commands/go_to_file.rs
+++ b/src/command/commands/go_to_file.rs
@@ -15,9 +15,17 @@ impl Command for GoToFirstLine {
     }
 
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        let target = if self.count == 0 { 0 } else { self.count - 1 };
+        let current_col = editor.cursor_position_in_buffer.col;
         let max_row = editor.buffer.lines.len().saturating_sub(1);
-        editor.move_cursor_to(target.min(max_row), 0)?;
+        let target = if self.count == 0 { 0 } else { self.count - 1 };
+        let target = target.min(max_row);
+        let dest_col = editor
+            .buffer
+            .lines
+            .get(target)
+            .map(|line| line.chars().count().min(current_col))
+            .unwrap_or(0);
+        editor.move_cursor_to(target, dest_col)?;
         Ok(())
     }
 
@@ -37,13 +45,21 @@ impl Command for GoToLastLine {
     }
 
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        let current_col = editor.cursor_position_in_buffer.col;
         let max_row = editor.buffer.lines.len().saturating_sub(1);
         let target = if self.count == 0 {
             max_row
         } else {
             self.count - 1
         };
-        editor.move_cursor_to(target.min(max_row), 0)?;
+        let target = target.min(max_row);
+        let dest_col = editor
+            .buffer
+            .lines
+            .get(target)
+            .map(|line| line.chars().count().min(current_col))
+            .unwrap_or(0);
+        editor.move_cursor_to(target, dest_col)?;
         Ok(())
     }
 

--- a/src/command/commands/go_to_file.rs
+++ b/src/command/commands/go_to_file.rs
@@ -17,8 +17,7 @@ impl Command for GoToFirstLine {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
         let current_col = editor.cursor_position_in_buffer.col;
         let max_row = editor.buffer.lines.len().saturating_sub(1);
-        let target = if self.count == 0 { 0 } else { self.count - 1 };
-        let target = target.min(max_row);
+        let target = if self.count == 0 { 0 } else { self.count - 1 }.min(max_row);
         let dest_col = editor
             .buffer
             .lines

--- a/src/command/compose.rs
+++ b/src/command/compose.rs
@@ -115,14 +115,14 @@ pub fn compose(key_events: &Vec<KeyEvent>) -> InputState {
             }
             KeyEvent {
                 code: KeyCode::Char('G'),
-                modifiers: KeyModifiers::NONE,
+                modifiers,
                 ..
-            } => {
+            } if (*modifiers == KeyModifiers::NONE || *modifiers == KeyModifiers::SHIFT) => {
                 if let InputState::Start = input_state {
                     return InputState::CommandCompleted(CommandData {
                         count: 0,
                         key_code: KeyCode::Char('G'),
-                        modifiers: KeyModifiers::NONE,
+                        modifiers: *modifiers,
                         range: None,
                     });
                 } else if let InputState::AccumulateDigits(digits) = input_state {
@@ -130,7 +130,7 @@ pub fn compose(key_events: &Vec<KeyEvent>) -> InputState {
                     return InputState::CommandCompleted(CommandData {
                         count,
                         key_code: KeyCode::Char('G'),
-                        modifiers: KeyModifiers::NONE,
+                        modifiers: *modifiers,
                         range: None,
                     });
                 } else {


### PR DESCRIPTION
## Summary
- keep column position for `G` and `gg`

## Testing
- `cargo test --verbose`
- `pytest e2e/test_motion_commands.py::test_motion_G -vv`
- `pytest e2e/test_motion_commands.py::test_motion_gg -vv` (fails)
- `pytest e2e --verbose` (fails)

------
https://chatgpt.com/codex/tasks/task_e_684503ee9f14832f8b1271658f2f3cfd