### PR TITLE
Fix cursor not showing last line

### DIFF
--- a/src/command/commands/append.rs
+++ b/src/command/commands/append.rs
@@ -44,7 +44,7 @@ impl Command for Append {
                 editor.cursor_position_on_screen.col += get_char_width(c);
                 if editor.cursor_position_on_screen.col >= editor.terminal_size.width {
                     editor.cursor_position_on_screen.col = 0;
-                    if editor.cursor_position_on_screen.row < editor.content_height() {
+                    if editor.cursor_position_on_screen.row < editor.max_content_row_index() {
                         editor.cursor_position_on_screen.row += 1;
                     } else {
                         editor.window_position_in_buffer.row += 1;

--- a/src/command/commands/move_cursor.rs
+++ b/src/command/commands/move_cursor.rs
@@ -22,7 +22,7 @@ impl Command for ForwardChar {
             editor.cursor_position_on_screen.col += char_width;
             if editor.cursor_position_on_screen.col >= editor.terminal_size.width {
                 editor.cursor_position_on_screen.col = 0;
-                if editor.cursor_position_on_screen.row < editor.content_height() {
+                if editor.cursor_position_on_screen.row < editor.max_content_row_index() {
                     editor.cursor_position_on_screen.row += 1;
                 } else {
                     editor.window_position_in_buffer.row += 1;
@@ -113,7 +113,7 @@ impl Command for NextLine {
             move_end_of_line.execute(editor)?;
 
             editor.cursor_position_in_buffer.row = next_row;
-            if editor.cursor_position_on_screen.row < editor.content_height() {
+            if editor.cursor_position_on_screen.row < editor.max_content_row_index() {
                 editor.cursor_position_on_screen.row += 1;
             } else {
                 editor.window_position_in_buffer.row += 1;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -789,6 +789,10 @@ impl Editor {
         self.terminal_size.height - 1
     }
 
+    pub fn max_content_row_index(&self) -> u16 {
+        self.content_height() - 1
+    }
+
     pub fn page_down(&mut self) -> GenericResult<()> {
         let height = self.content_height() as usize;
         let col = self.cursor_position_in_buffer.col;
@@ -852,7 +856,7 @@ impl Editor {
         self.cursor_position_on_screen.col += char_width;
         if self.cursor_position_on_screen.col >= self.terminal_size.width {
             self.cursor_position_on_screen.col = 0;
-            if self.cursor_position_on_screen.row < self.content_height() {
+            if self.cursor_position_on_screen.row < self.max_content_row_index() {
                 self.cursor_position_on_screen.row += 1;
             } else {
                 self.window_position_in_buffer.row += 1;
@@ -880,7 +884,7 @@ impl Editor {
         self.cursor_position_on_screen.col += char_width;
         if self.cursor_position_on_screen.col >= self.terminal_size.width {
             self.cursor_position_on_screen.col = 0;
-            if self.cursor_position_on_screen.row < self.content_height() {
+            if self.cursor_position_on_screen.row < self.max_content_row_index() {
                 self.cursor_position_on_screen.row += 1;
             } else {
                 self.window_position_in_buffer.row += 1;
@@ -1047,7 +1051,7 @@ impl Editor {
             .insert(self.cursor_position_in_buffer.row + 1, rest_of_line);
         self.cursor_position_in_buffer.row += 1;
         self.cursor_position_in_buffer.col = 0;
-        if self.cursor_position_on_screen.row < self.content_height() {
+        if self.cursor_position_on_screen.row < self.max_content_row_index() {
             self.cursor_position_on_screen.row += 1;
         } else {
             self.window_position_in_buffer.row += 1;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -790,7 +790,7 @@ impl Editor {
     }
 
     pub fn max_content_row_index(&self) -> u16 {
-        self.content_height() - 1
+        self.content_height().saturating_sub(1)
     }
 
     pub fn page_down(&mut self) -> GenericResult<()> {


### PR DESCRIPTION
## Summary
- avoid using bottom command line as cursor position
- add `Editor::max_content_row_index`
- scroll properly when moving past content area

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e/test_motion_commands.py::test_motion_l -vv`
- `pytest e2e/test_ex_commands.py::test_move_line -vv`


------
https://chatgpt.com/codex/tasks/task_e_68453a78745c832f94d8a071ef856d7d