### PR TITLE
Fix viewport scroll for G on wrapped lines

### DIFF
--- a/src/command/commands/go_to_file.rs
+++ b/src/command/commands/go_to_file.rs
@@ -59,6 +59,9 @@ impl Command for GoToLastLine {
             .map(|line| line.chars().count().saturating_sub(1).min(current_col))
             .unwrap_or(0);
         editor.move_cursor_to(target, dest_col)?;
+        if target == max_row {
+            editor.scroll_to_cursor_bottom();
+        }
         Ok(())
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -822,6 +822,38 @@ impl Editor {
         Ok(())
     }
 
+    fn line_height(&self, row: usize) -> usize {
+        let width = self.terminal_size.width as usize;
+        self.buffer
+            .lines
+            .get(row)
+            .map(|line| {
+                let len = line.chars().count();
+                if len == 0 {
+                    1
+                } else {
+                    (len - 1) / width + 1
+                }
+            })
+            .unwrap_or(1)
+    }
+
+    pub fn scroll_to_cursor_bottom(&mut self) {
+        let height = self.content_height() as usize;
+        let mut rows_needed = self.line_height(self.cursor_position_in_buffer.row);
+        let mut start = self.cursor_position_in_buffer.row;
+        while start > 0 && rows_needed < height {
+            start -= 1;
+            rows_needed += self.line_height(start);
+        }
+        self.window_position_in_buffer.row = start;
+        let mut pos = 0usize;
+        for r in start..self.cursor_position_in_buffer.row {
+            pos += self.line_height(r);
+        }
+        self.cursor_position_on_screen.row = pos as u16;
+    }
+
     pub fn display_visual_bell(&mut self) -> GenericResult<()> {
         let mut stdout = std::io::stdout();
         stdout.write_all(b"\x07")?;


### PR DESCRIPTION
## Summary
- keep the last line fully visible when jumping to it
- adjust window start based on wrapped line height

## Testing
- `cargo build --verbose` *(fails: command not found)*
- `cargo test --verbose` *(fails: command not found)*
- `pytest e2e --verbose` *(fails: FileNotFoundError: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684562edc9ec832fb535867a0fa9d234