### PR TITLE
Implement print command and tests

### DIFF
--- a/e2e/test_ex_commands.py
+++ b/e2e/test_ex_commands.py
@@ -150,3 +150,8 @@ def test_move_reverse_range_undo():
 def test_move_reverse_range_repeat():
     result = run_commands([':3,1m$\r', '.'], initial_content='1\n2\n3\n4\n')
     assert result.splitlines() == ['4', '1', '2', '3']
+
+
+def test_print_range():
+    result = run_commands([':1,3p\r'], initial_content='1\n2\n3\n4\n', exit_cmd=':q!\r')
+    assert result.splitlines() == ['1', '2', '3', '4']

--- a/src/command/commands/print.rs
+++ b/src/command/commands/print.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::io::{stdout, Write};
 
 use crate::command::base::Command;
 use crate::data::LineRange;
@@ -12,13 +13,80 @@ pub struct PrintCommand {
 }
 
 impl Command for PrintCommand {
-    fn execute(&mut self, _editor: &mut Editor) -> GenericResult<()> {
-        // TODO: Implement PrintCommand
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
         log::info!("PrintCommand execute");
+
+        if editor.buffer.lines.is_empty() {
+            return Ok(());
+        }
+
+        let mut start = editor.get_line_number_from(&self.line_range.start);
+        let mut end = editor.get_line_number_from(&self.line_range.end);
+        let last = editor.buffer.lines.len().saturating_sub(1);
+
+        if start > last {
+            start = last;
+        }
+        if end > last {
+            end = last;
+        }
+        if start > end {
+            std::mem::swap(&mut start, &mut end);
+        }
+
+        let mut out = stdout();
+        let mut collected = Vec::new();
+        for idx in start..=end {
+            if let Some(line) = editor.buffer.lines.get(idx) {
+                writeln!(out, "{}", line)?;
+                collected.push(line.clone());
+            }
+        }
+        out.flush()?;
+
+        editor.status_line = collected.join("\n");
         Ok(())
     }
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{LineAddressType, LineRange, SimpleLineAddressType};
+
+    #[test]
+    fn print_single_line() {
+        let mut editor = Editor::new();
+        editor.buffer.lines = vec!["one".into(), "two".into()];
+
+        let mut cmd = PrintCommand {
+            line_range: LineRange {
+                start: LineAddressType::Absolute(SimpleLineAddressType::LineNumber(1)),
+                end: LineAddressType::Absolute(SimpleLineAddressType::LineNumber(1)),
+            },
+        };
+
+        cmd.execute(&mut editor).unwrap();
+        assert_eq!(editor.status_line, "one");
+    }
+
+    #[test]
+    fn print_range() {
+        let mut editor = Editor::new();
+        editor.buffer.lines = vec!["a".into(), "b".into(), "c".into(), "d".into()];
+
+        let mut cmd = PrintCommand {
+            line_range: LineRange {
+                start: LineAddressType::Absolute(SimpleLineAddressType::LineNumber(1)),
+                end: LineAddressType::Absolute(SimpleLineAddressType::LineNumber(3)),
+            },
+        };
+
+        cmd.execute(&mut editor).unwrap();
+        assert_eq!(editor.status_line, "a\nb\nc");
     }
 }


### PR DESCRIPTION
## Summary
- implement `PrintCommand::execute`
- print selected line range and store in `status_line`
- unit tests for printing lines
- e2e test for `:1,3p`

## Testing
- `cargo test --quiet`
- `pytest e2e/test_ex_commands.py::test_print_range -q`
- `pytest e2e -q` *(fails: TIMEOUT errors)*

------
https://chatgpt.com/codex/tasks/task_e_68457325eb44832fad6d777e6c90998e