### PR TITLE
Fix undo cursor restore for CopyLines

### DIFF
--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -232,6 +232,7 @@ impl Parser {
         let cp = copy_lines::CopyLines {
             line_range: line_range.clone(),
             address,
+            editor_cursor_data: None,
             insertion_idx: None,
             copied_len: 0,
         };


### PR DESCRIPTION
## Summary
- capture cursor data before executing CopyLines command
- restore cursor on undo
- keep redo behavior consistent
- test cursor position after undo of `:copy`

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e/test_ex_commands.py::test_copy_line_undo -q`
- `pytest e2e --verbose` *(fails: test_copy_line, test_copy_reverse_range, test_move_reverse_range_undo, test_motion_l, test_motion_gg, test_motion_ctrl_b)*

------
https://chatgpt.com/codex/tasks/task_e_68457817efdc832fbce7033ab78a5a34