### PR TITLE
Fix motion semantics

### DIFF
--- a/e2e/test_motion_commands.py
+++ b/e2e/test_motion_commands.py
@@ -97,6 +97,16 @@ def test_motion_w():
     )
 
 
+def test_motion_w_punctuation():
+    run_motion_test(
+        file_content="foo,bar",
+        terminal_size=(24, 80),
+        initial_cursor_pos=(1, 1),
+        command_to_test="w",
+        expected_cursor_pos=(1, 5),
+    )
+
+
 def test_motion_dollar():
     run_motion_test(
         file_content="hello world\n",
@@ -113,6 +123,16 @@ def test_motion_l():
         initial_cursor_pos=(1, 1),
         command_to_test="l",
         expected_cursor_pos=(1, 2),
+    )
+
+
+def test_motion_l_at_eol():
+    run_motion_test(
+        file_content="abc\n",
+        terminal_size=(24, 80),
+        initial_cursor_pos=(1, 3),
+        command_to_test="l",
+        expected_cursor_pos=(1, 3),
     )
 
 
@@ -145,6 +165,16 @@ def test_motion_gg():
         initial_cursor_pos=(3, 1),
         command_to_test="gg",
         expected_cursor_pos=(1, 1),
+    )
+
+
+def test_motion_count_gg():
+    run_motion_test(
+        file_content="line1\nline2\nline3\n",
+        terminal_size=(24, 80),
+        initial_cursor_pos=(1, 1),
+        command_to_test="2gg",
+        expected_cursor_pos=(2, 1),
     )
 
 # def test_motion_ctrl_b():

--- a/src/command/commands/move_cursor.rs
+++ b/src/command/commands/move_cursor.rs
@@ -28,6 +28,8 @@ impl Command for ForwardChar {
                     editor.window_position_in_buffer.row += 1;
                 }
             }
+        } else {
+            editor.display_visual_bell()?;
         }
         Ok(())
     }
@@ -184,19 +186,21 @@ impl Command for ForwardWord {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
         let mut forward_char = ForwardChar {};
         let mut num_of_chars = editor.get_num_of_current_line_chars();
+
         forward_char.execute(editor)?;
+
         'outer: loop {
             if editor.cursor_position_in_buffer.col + 1 < num_of_chars {
                 while editor.cursor_position_in_buffer.col + 1 < num_of_chars {
                     let c = editor.get_current_char().unwrap();
-                    if c.is_whitespace() {
+                    if !c.is_alphanumeric() && c != '_' {
                         break;
                     }
                     forward_char.execute(editor)?;
                 }
                 while editor.cursor_position_in_buffer.col + 1 < num_of_chars {
                     let c = editor.get_current_char().unwrap();
-                    if !c.is_whitespace() {
+                    if c.is_alphanumeric() || c == '_' {
                         break 'outer;
                     }
                     forward_char.execute(editor)?;
@@ -209,7 +213,7 @@ impl Command for ForwardWord {
                 num_of_chars = editor.get_num_of_current_line_chars();
                 while editor.cursor_position_in_buffer.col + 1 < num_of_chars {
                     let c = editor.get_current_char().unwrap();
-                    if !c.is_whitespace() {
+                    if c.is_alphanumeric() || c == '_' {
                         break 'outer;
                     }
                     forward_char.execute(editor)?;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -806,10 +806,12 @@ impl Editor {
 
     pub fn page_down(&mut self) -> GenericResult<()> {
         let height = self.content_height() as usize;
+        let overlap = if height > 1 { 2 } else { 1 };
+        let scroll = height.saturating_sub(overlap);
         let col = self.cursor_position_in_buffer.col;
         let max_top = self.buffer.lines.len().saturating_sub(1);
         self.window_position_in_buffer.row =
-            (self.window_position_in_buffer.row + height).min(max_top);
+            (self.window_position_in_buffer.row + scroll).min(max_top);
         self.cursor_position_in_buffer.row = self.window_position_in_buffer.row;
         self.cursor_position_in_buffer.col = 0;
         self.cursor_position_on_screen.row = 0;
@@ -821,9 +823,11 @@ impl Editor {
 
     pub fn page_up(&mut self) -> GenericResult<()> {
         let height = self.content_height() as usize;
+        let overlap = if height > 1 { 2 } else { 1 };
+        let scroll = height.saturating_sub(overlap);
         let col = self.cursor_position_in_buffer.col;
         self.window_position_in_buffer.row =
-            self.window_position_in_buffer.row.saturating_sub(height);
+            self.window_position_in_buffer.row.saturating_sub(scroll);
         self.cursor_position_in_buffer.row = self.window_position_in_buffer.row;
         self.cursor_position_in_buffer.col = 0;
         self.cursor_position_on_screen.row = 0;
@@ -1402,7 +1406,7 @@ mod tests {
         ];
 
         editor.page_down().unwrap();
-        assert_eq!(editor.cursor_position_in_buffer.row, 3);
+        assert_eq!(editor.cursor_position_in_buffer.row, 1);
 
         editor.page_up().unwrap();
         assert_eq!(editor.cursor_position_in_buffer.row, 0);


### PR DESCRIPTION
## Summary
- adjust forward word logic to stop after punctuation
- prevent forward char past end-of-line
- scroll with two-line overlap when paging
- expand motion e2e tests

## Testing
- `cargo test --verbose`
- `pytest e2e --verbose` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68457da039dc832fa39eaa5c89228a94