### PR TITLE
Handle invalid command state

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -46,8 +46,9 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                                 event_keys.clear();
                             }
                             InputState::CommandInvalid(key_codes) => {
-                                //　TODO: error message
                                 error!("Invalid command: {:?}", key_codes);
+                                editor.status_line = "?".to_string();
+                                editor.display_visual_bell()?;
                                 event_keys.clear();
                             }
                             _ => {


### PR DESCRIPTION
## Summary
- signal invalid commands by showing `?` on the status line
- blink the terminal on invalid commands
- test invalid command status line feedback

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e/test_vi_commands.py::test_invalid_command_shows_status_line -vv`
- `pytest e2e --maxfail=1 --verbose` *(fails: Timeout in test_substitute_range_repeat)*

------
https://chatgpt.com/codex/tasks/task_e_6845fd9feba8832faa8c664b253f691e