### PR TITLE
Adjust e2e test timing

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -5,6 +5,10 @@ import pytest
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 EVI_BIN = os.path.join(ROOT_DIR, 'target', 'debug', 'evi')
 
+# Increase the delay between keystrokes to avoid timing issues in slow
+# environments such as CI containers.
+os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.1')
+
 @pytest.fixture(scope='session', autouse=True)
 def build_evi():
     subprocess.run(['cargo', 'build'], cwd=ROOT_DIR, check=True)

--- a/e2e/helpers.py
+++ b/e2e/helpers.py
@@ -35,7 +35,7 @@ def run_commands(commands, initial_content="", exit_cmd=":wq\r"):
         # The value can be overridden using ``EVI_DELAY_BEFORE_SEND`` for
         # experimentation, but defaults to 0.1 seconds. ``EVI_DELAY_AFTER_ESC``
         # can be used to delay after sending ESC and defaults to 0.05 seconds.
-        child.delaybeforesend = float(os.getenv("EVI_DELAY_BEFORE_SEND", "0.01"))
+        child.delaybeforesend = float(os.getenv("EVI_DELAY_BEFORE_SEND", "0.1"))
         delay_after_esc = float(os.getenv("EVI_DELAY_AFTER_ESC", "0.05"))
 
         for c in commands:

--- a/e2e/test_ex_commands.py
+++ b/e2e/test_ex_commands.py
@@ -81,7 +81,7 @@ def test_copy_line_undo():
         env = os.environ.copy()
         env.setdefault('TERM', 'xterm')
         child = pexpect.spawn(EVI_BIN, [path], env=env, encoding='utf-8')
-        child.delaybeforesend = float(os.getenv('EVI_DELAY_BEFORE_SEND', '0.01'))
+        child.delaybeforesend = float(os.getenv('EVI_DELAY_BEFORE_SEND', '0.1'))
 
         get_screen_and_cursor(child)
         child.send(':1co5\r')


### PR DESCRIPTION
## Summary
- make sure e2e tests use a higher default delay before sending keystrokes
- apply the same delay in a few tests via the `EVI_DELAY_BEFORE_SEND` env variable
- set the env var in `conftest.py` for consistency

## Testing
- `cargo test --verbose`
- `pytest e2e -q` *(fails: assert (3, 1) == (1, 1))*

------
https://chatgpt.com/codex/tasks/task_e_68460314f734832f88843cebe5c91b08