### PR TITLE
Switch parser debug print to log

### DIFF
--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -18,6 +18,7 @@ use crate::generic_error::GenericError;
 
 use crate::command::commands::exit;
 use crate::command::commands::print;
+use log::debug;
 use crate::command::commands::write;
 
 enum MyOption<T> {
@@ -58,7 +59,7 @@ pub struct Parser {
 impl Parser {
     pub fn new(input: &str) -> Self {
         let tokens = lexer::tokenize(input);
-        println!("tokens {:?}", tokens);
+        debug!("tokens {:?}", tokens);
         Parser {
             original_tokens: tokens.clone(),
             tokens,


### PR DESCRIPTION
## Summary
- enable togglable debug logging in `Parser` by switching println to `log::debug!`

## Testing
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_684645d4d32c832fa637ac3ad0e4de5f