### PR TITLE
Fix Append cursor advance

### DIFF
--- a/src/command/commands/append.rs
+++ b/src/command/commands/append.rs
@@ -39,22 +39,22 @@ impl Command for Append {
         if editor.is_insert_mode() {
             // do nothing
         } else {
-            if let Some(c) = editor.get_current_char() {
-                editor.cursor_position_in_buffer.col += 1;
-                editor.cursor_position_on_screen.col += get_char_width(c);
-                if editor.cursor_position_on_screen.col >= editor.terminal_size.width {
-                    editor.cursor_position_on_screen.col = 0;
-                    if editor.cursor_position_on_screen.row < editor.max_content_row_index() {
-                        editor.cursor_position_on_screen.row += 1;
-                    } else {
-                        editor.window_position_in_buffer.row += 1;
-                    }
+            let width = editor
+                .get_current_char()
+                .map(get_char_width)
+                .unwrap_or(0);
+            editor.cursor_position_in_buffer.col += 1;
+            editor.cursor_position_on_screen.col += width;
+            if editor.cursor_position_on_screen.col >= editor.terminal_size.width {
+                editor.cursor_position_on_screen.col = 0;
+                if editor.cursor_position_on_screen.row < editor.max_content_row_index() {
+                    editor.cursor_position_on_screen.row += 1;
+                } else {
+                    editor.window_position_in_buffer.row += 1;
                 }
-                self.editor_cursor_data = Some(editor.snapshot_cursor_data());
-                editor.set_insert_mode();
-            } else {
-                return Err("Failed to get current char".into());
             }
+            self.editor_cursor_data = Some(editor.snapshot_cursor_data());
+            editor.set_insert_mode();
         }
         Ok(())
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1526,4 +1526,27 @@ mod tests {
         editor.open_file(&path);
         assert!(editor.status_line.starts_with("Failed to open file"));
     }
+
+    #[test]
+    fn test_append_at_end_of_line() {
+        use crate::command::base::CommandData;
+        use crossterm::event::KeyCode;
+
+        let mut editor = Editor::new();
+        editor.resize_terminal(80, 24);
+        editor.buffer.lines = vec!["abc".to_string()];
+        editor.move_cursor_to(0, 2).unwrap();
+
+        let cmd = CommandData {
+            count: 1,
+            key_code: KeyCode::Char('a'),
+            modifiers: crossterm::event::KeyModifiers::NONE,
+            range: None,
+        };
+        editor.execute_command(cmd).unwrap();
+
+        assert!(editor.is_insert_mode());
+        assert_eq!(editor.cursor_position_in_buffer.col, 3);
+        assert_eq!(editor.cursor_position_on_screen.col, 3);
+    }
 }


### PR DESCRIPTION
## Summary
- handle cases where no character is under the cursor when appending
- add regression test for `Append` command at end of line

## Testing
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose` *(fails: test_motion_w_punctuation, test_motion_gg, test_motion_ctrl_f, test_motion_ctrl_b)*

------
https://chatgpt.com/codex/tasks/task_e_684646a2f7e0832fbac4b82dd3103e7b