### PR TITLE
Fix flaky e2e tests in slower environments

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -8,6 +8,12 @@ EVI_BIN = os.path.join(ROOT_DIR, 'target', 'debug', 'evi')
 # Increase the delay between keystrokes to avoid timing issues in slow
 # environments such as CI containers.
 os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.1')
+# Slow execution environments (like the Codex workspace container) may take
+# longer to output screen updates. ``EVI_PEXPECT_TIMEOUT`` controls how long the
+# helper functions wait when reading from the spawned ``evi`` process.  The
+# default of ``0.3`` seconds is sometimes too short here which leads to spurious
+# timeouts.  Increase it slightly unless it has been configured explicitly.
+os.environ.setdefault('EVI_PEXPECT_TIMEOUT', '1')
 
 @pytest.fixture(scope='session', autouse=True)
 def build_evi():


### PR DESCRIPTION
## Summary
- add a larger default value for `EVI_PEXPECT_TIMEOUT` so that e2e
  tests do not fail due to slow screen updates

## Testing
- `cargo test`
- `pytest e2e/test_basic.py::test_insert_and_save -vv`


------
https://chatgpt.com/codex/tasks/task_e_68464c8b6e6c832f9246c57cc2f12d8f