### PR TITLE
Fix undo logic for Unicode insert text

### DIFF
--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -123,6 +123,16 @@ def test_word_motion_w_b():
     assert result.strip() == 'ne wo'
 
 
+def test_insert_unicode_undo():
+    result = run_commands(['i', 'あい\nう', '\x1b', 'u'], initial_content='foo\n')
+    assert result.strip() == 'foo'
+
+
+def test_append_unicode_undo():
+    result = run_commands(['a', '🍣', '\x1b', 'u'], initial_content='bar\n')
+    assert result.strip() == 'bar'
+
+
 def _parse_screen(screen: str) -> dict[int, str]:
     import re
     rows: dict[int, str] = {}

--- a/src/command/commands/append.rs
+++ b/src/command/commands/append.rs
@@ -79,7 +79,7 @@ impl Command for Append {
                     let new_line: String = line
                         .chars()
                         .take(col)
-                        .chain(line.chars().skip(col + text.len()))
+                        .chain(line.chars().skip(col + text.chars().count()))
                         .collect();
                     editor.buffer.lines[row] = new_line;
                 } else if input_text_lines.len() >= 2 {
@@ -88,7 +88,7 @@ impl Command for Append {
                     let last_line = editor.buffer.lines[row + input_text_lines.len() - 1].clone();
                     let new_first_line: String = first_line.chars().take(col).collect();
                     let new_last_line: String =
-                        last_line.chars().skip(last_input_line.len()).collect();
+                        last_line.chars().skip(last_input_line.chars().count()).collect();
                     editor.buffer.lines[row] = new_first_line + new_last_line.as_str();
                     for _ in 0..input_text_lines.len() - 1 {
                         editor.buffer.lines.remove(row + 1);

--- a/src/command/commands/insert.rs
+++ b/src/command/commands/insert.rs
@@ -66,7 +66,7 @@ impl Command for Insert {
                     let new_line: String = line
                         .chars()
                         .take(col)
-                        .chain(line.chars().skip(col + text.len()))
+                        .chain(line.chars().skip(col + text.chars().count()))
                         .collect();
                     editor.buffer.lines[row] = new_line;
                 } else if input_text_lines.len() >= 2 {
@@ -75,7 +75,7 @@ impl Command for Insert {
                     let last_line = editor.buffer.lines[row + input_text_lines.len() - 1].clone();
                     let new_first_line: String = first_line.chars().take(col).collect();
                     let new_last_line: String =
-                        last_line.chars().skip(last_input_line.len()).collect();
+                        last_line.chars().skip(last_input_line.chars().count()).collect();
                     editor.buffer.lines[row] = new_first_line + new_last_line.as_str();
                     for _ in 0..input_text_lines.len() - 1 {
                         editor.buffer.lines.remove(row + 1);


### PR DESCRIPTION
## Summary
- handle character counts when undoing inserts and appends
- test Unicode insertion undo cases

## Testing
- `cargo test --verbose`
- `pytest e2e --verbose` *(fails: 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68465203cb8c832fa0775070aa92a8db