### PR TITLE
Improve e2e docs for slow environments

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -43,9 +43,9 @@ This script builds the Docker image based on the official `rust` image, mounts t
 When running in slower containers, `pexpect` may time out before `evi` responds.
 To increase reliability, you can adjust the following environment variables:
 
-- `EVI_DELAY_BEFORE_SEND` – wait before sending each key
-- `EVI_DELAY_AFTER_ESC` – delay after pressing Escape
-- `EVI_PEXPECT_TIMEOUT` – how long to wait for output
+- `EVI_DELAY_BEFORE_SEND` – Delay (in seconds) before sending each keystroke to `evi` (default: 0.1s).
+- `EVI_DELAY_AFTER_ESC` – Delay (in seconds) after sending an Escape (ESC) key (default: 0.05s).
+- `EVI_PEXPECT_TIMEOUT` – Timeout (in seconds) for `pexpect` when waiting for `evi`'s output (default: 1s).
 
 Example command:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -37,3 +37,20 @@ scripts/e2e_docker.sh
 ```
 
 This script builds the Docker image based on the official `rust` image, mounts the project directory into the container, and runs `cargo build --verbose` followed by `pytest e2e --verbose`. The Docker image installs the Python dependencies in a virtual environment to avoid system package conflicts.
+
+## Handling slow environments
+
+When running in slower containers, `pexpect` may time out before `evi` responds.
+To increase reliability, you can adjust the following environment variables:
+
+- `EVI_DELAY_BEFORE_SEND` – wait before sending each key
+- `EVI_DELAY_AFTER_ESC` – delay after pressing Escape
+- `EVI_PEXPECT_TIMEOUT` – how long to wait for output
+
+Example command:
+
+```bash
+EVI_PEXPECT_TIMEOUT=2 EVI_DELAY_BEFORE_SEND=0.2 pytest e2e --verbose
+```
+
+Higher values may be required when running inside the Codex workspace.


### PR DESCRIPTION
## Summary
- document how to slow down interactions in e2e tests

## Testing
- `cargo test --verbose`
- `pytest e2e --verbose` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_684655bb0dcc832f883b7502f8c36b76