### PR TITLE
Increase default pexpect timeout

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -12,8 +12,8 @@ os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.1')
 # longer to output screen updates. ``EVI_PEXPECT_TIMEOUT`` controls how long the
 # helper functions wait when reading from the spawned ``evi`` process.  The
 # default of ``0.3`` seconds is sometimes too short here which leads to spurious
-# timeouts.  Increase it slightly unless it has been configured explicitly.
-os.environ.setdefault('EVI_PEXPECT_TIMEOUT', '1')
+# timeouts.  Increase it to 2 seconds unless it has been configured explicitly.
+os.environ.setdefault('EVI_PEXPECT_TIMEOUT', '2')
 
 @pytest.fixture(scope='session', autouse=True)
 def build_evi():


### PR DESCRIPTION
## Summary
- increase default `EVI_PEXPECT_TIMEOUT` to 2s
- update comment in `conftest.py`

## Testing
- `pip install -r e2e/requirements.txt`
- `pytest e2e` *(fails: 9 failed, 64 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_684655ca08f4832f81d7e8db57cf9d52