### PR TITLE
Fix e2e timing after goto

### DIFF
--- a/e2e/test_motion_commands.py
+++ b/e2e/test_motion_commands.py
@@ -78,6 +78,8 @@ def run_motion_test(
 
         # Move to the requested starting position
         goto(child, initial_cursor_pos[0], initial_cursor_pos[1])
+        # Wait for the cursor to settle in slower environments
+        get_screen_and_cursor(child)
 
         # Send the command to test
         child.send(command_to_test)

--- a/e2e/test_wrapping.py
+++ b/e2e/test_wrapping.py
@@ -60,6 +60,8 @@ def test_cursor_j_k_on_wrapped_line():
         # Ensure the editor has finished drawing
         get_screen_and_cursor(child)
         goto(child, 1, 1)
+        # Wait for the cursor to settle before sending movement commands
+        get_screen_and_cursor(child)
 
         child.send("j")
         _, pos = get_screen_and_cursor(child)


### PR DESCRIPTION
## Summary
- wait for screen updates after calling `goto` in tests
- ensure wrapping tests also wait for cursor settling

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6846603ad26c832f8e22c3acb7fc3a37