### PR TITLE
Fix escape sequence warning in e2e tests

### DIFF
--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -164,7 +164,7 @@ def test_invalid_command_shows_status_line(tmp_path):
     # Send an invalid command sequence and check status line
     child.send("dZ")
     child.expect("\x07")
-    child.expect("\?")
+    child.expect(r"\?")
 
     child.send(":q!\r")
     child.expect(pexpect.EOF)


### PR DESCRIPTION
## Summary
- fix DeprecationWarning in `test_vi_commands`

## Testing
- `cargo test --quiet`
- `pytest e2e/test_vi_commands.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68466b5ed7a8832f955be4505915c280