### PR TITLE
Implement join-lines command

### DIFF
--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -46,6 +46,16 @@ def test_open_line_above_undo():
     assert result.strip() == 'second'
 
 
+def test_join_lines():
+    result = run_commands(['J'], initial_content='a\nb\n')
+    assert result.splitlines() == ['ab']
+
+
+def test_join_lines_undo():
+    result = run_commands(['J', 'u'], initial_content='a\nb\n')
+    assert result.splitlines() == ['a', 'b']
+
+
 def test_open_line_above_repeat():
     result = run_commands(['O', 'first', '\x1b', '.', '\x1b'], initial_content='second\n')
     # TODO: repeating open line should insert another line but is not implemented yet

--- a/src/command/commands/join_lines.rs
+++ b/src/command/commands/join_lines.rs
@@ -1,0 +1,106 @@
+use std::any::Any;
+
+use crate::command::base::Command;
+use crate::editor::{Editor, EditorCursorData};
+use crate::generic_error::GenericResult;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct JoinLines {
+    pub editor_cursor_data: Option<EditorCursorData>,
+    pub first: Option<String>,
+    pub second: Option<String>,
+}
+
+impl Default for JoinLines {
+    fn default() -> Self {
+        Self {
+            editor_cursor_data: None,
+            first: None,
+            second: None,
+        }
+    }
+}
+
+impl Command for JoinLines {
+    fn is_reusable(&self) -> bool {
+        false
+    }
+
+    fn is_undoable(&self) -> bool {
+        true
+    }
+
+    fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        let row = editor.cursor_position_in_buffer.row;
+        if row + 1 >= editor.buffer.lines.len() {
+            return Ok(());
+        }
+        editor.is_dirty = true;
+        self.editor_cursor_data = Some(editor.snapshot_cursor_data());
+        self.first = Some(editor.buffer.lines[row].clone());
+        self.second = Some(editor.buffer.lines[row + 1].clone());
+
+        let new_line = format!("{}{}", self.first.as_ref().unwrap(), self.second.as_ref().unwrap());
+        editor.buffer.lines[row] = new_line;
+        editor.buffer.lines.remove(row + 1);
+        Ok(())
+    }
+
+    fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
+        if let (Some(cursor), Some(first), Some(second)) = (
+            self.editor_cursor_data,
+            &self.first,
+            &self.second,
+        ) {
+            let row = cursor.cursor_position_in_buffer.row;
+            if row < editor.buffer.lines.len() {
+                editor.buffer.lines[row] = first.clone();
+                editor.buffer.lines.insert(row + 1, second.clone());
+            }
+            editor.restore_cursor_data(cursor);
+        }
+        Ok(())
+    }
+
+    fn redo(&mut self, editor: &mut Editor) -> GenericResult<Option<Box<dyn Command>>> {
+        editor.is_dirty = true;
+        let mut new_cmd = Box::new(JoinLines::default());
+        new_cmd.execute(editor)?;
+        Ok(Some(new_cmd))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::Editor;
+
+    #[test]
+    fn join_two_lines() {
+        let mut editor = Editor::new();
+        editor.terminal_size = crate::editor::TerminalSize { width: 80, height: 24 };
+        editor.buffer.lines = vec!["foo".to_string(), "bar".to_string()];
+
+        let mut cmd = JoinLines::default();
+        cmd.execute(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, vec!["foobar".to_string()]);
+        cmd.undo(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, vec!["foo".to_string(), "bar".to_string()]);
+    }
+
+    #[test]
+    fn join_multiple_lines() {
+        let mut editor = Editor::new();
+        editor.terminal_size = crate::editor::TerminalSize { width: 80, height: 24 };
+        editor.buffer.lines = vec!["1".to_string(), "2".to_string(), "3".to_string()];
+        let mut cmd = JoinLines::default();
+        cmd.execute(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, vec!["12".to_string(), "3".to_string()]);
+        cmd.redo(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, vec!["123".to_string()]);
+    }
+}

--- a/src/command/commands/mod.rs
+++ b/src/command/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod move_cursor;
 pub mod move_lines;
 pub mod no_op_command;
 pub mod open_line;
+pub mod join_lines;
 pub mod paste;
 pub mod append_line_end;
 pub mod print;

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -13,6 +13,7 @@ use super::commands::insert::Insert;
 use super::commands::insert_line_start::InsertLineStart;
 use super::commands::misc::DisplayFile;
 use super::commands::open_line::OpenLine;
+use super::commands::join_lines::JoinLines;
 use super::commands::paste::Paste;
 use super::commands::append_line_end::AppendLineEnd;
 use super::commands::search::RepeatSearch;
@@ -189,6 +190,12 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             above: true,
             ..Default::default()
         }),
+
+        // join lines command
+        CommandData {
+            key_code: KeyCode::Char('J'),
+            ..
+        } => Box::new(JoinLines::default()),
 
         // delete commands
         CommandData {

--- a/src/command/key_codes.rs
+++ b/src/command/key_codes.rs
@@ -25,7 +25,7 @@ pub fn is_editing_command_without_range(key: &KeyCode) -> bool {
         Char('x') | Char('X') | Char('r') | Char('R') => true,
         // '.' repeats the last command which may originate from any category,
         // but it is parsed as a standalone editing command without a range.
-        Char('D') | Char('p') | Char('P') | Char('~') | Char('.') => true,
+        Char('D') | Char('p') | Char('P') | Char('~') | Char('.') | Char('J') => true,
         Char('u') => true,
         _ => false,
     }


### PR DESCRIPTION
## Summary
- add `JoinLines` command with undo/redo support
- map `J` to `JoinLines`
- recognize `J` in command parsing
- test join-lines behavior via unit tests and e2e

## Testing
- `cargo test --quiet`
- `pytest e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68467a437b18832fb9cac6f6e567c82c