### PR TITLE
Add complex ex range support

### DIFF
--- a/e2e/test_ex_commands.py
+++ b/e2e/test_ex_commands.py
@@ -189,3 +189,14 @@ def test_global_print():
     content = 'foo\nbar\nfoo\n'
     result = run_commands([':g/foo/p\r'], initial_content=content, exit_cmd=':q!\r')
     assert result.splitlines() == ['foo', 'bar', 'foo']
+
+
+def test_print_dot_to_last():
+    result = run_commands([':.,$p\r'], initial_content='1\n2\n3\n', exit_cmd=':q!\r')
+    assert result.splitlines() == ['1', '2', '3']
+
+
+def test_delete_search_offset():
+    content = 'a\nfoo\nb\nc\n'
+    result = run_commands([':/foo/+1d\r'], initial_content=content)
+    assert result.splitlines() == ['a', 'foo', 'c']

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -383,7 +383,7 @@ impl Parser {
         let base = if self.accept_type(TokenType::Number) {
             if let MyOption::Some(token) = self.pop() {
                 let number = token.lexeme.clone();
-                Some(SimpleLineAddressType::LineNumber(number.parse().unwrap()))
+Some(SimpleLineAddressType::LineNumber(number.parse().map_err(|e| GenericError::from(format!("Invalid line number '{}': {}", number, e)))?))
             } else {
                 None
             }

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -418,7 +418,7 @@ Some(SimpleLineAddressType::LineNumber(number.parse().map_err(|e| GenericError::
                     self.pop();
                     let value = if self.accept_type(TokenType::Number) {
                         if let MyOption::Some(tok) = self.pop() {
-                            tok.lexeme.parse::<isize>().unwrap_or(1)
+tok.lexeme.parse::<isize>().map_err(|e| GenericError::from(format!("Invalid offset number '{}': {}", tok.lexeme, e)))?
                         } else {
                             1
                         }

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -430,7 +430,7 @@ tok.lexeme.parse::<isize>().map_err(|e| GenericError::from(format!("Invalid offs
                     self.pop();
                     let value = if self.accept_type(TokenType::Number) {
                         if let MyOption::Some(tok) = self.pop() {
-                            tok.lexeme.parse::<isize>().unwrap_or(1)
+tok.lexeme.parse::<isize>().map_err(|e| GenericError::from(format!("Invalid offset number '{}': {}", tok.lexeme, e)))?
                         } else {
                             1
                         }


### PR DESCRIPTION
## Summary
- improve line address parsing with pattern offsets and +/- adjustments
- compute ex line numbers via helper to resolve patterns and offsets
- test editor line resolution with positive offsets
- test parser range handling including pattern offsets
- expand e2e coverage for pattern address deletion and `.,$` range

## Testing
- `cargo test --verbose`
- `pytest e2e --maxfail=1 -vv` *(fails: test_cursor_j_k_on_wrapped_line)*

------
https://chatgpt.com/codex/tasks/task_e_68468908da60832f936c70863d46f4d6