### PR TITLE
Add ex command filename completion

### DIFF
--- a/src/command/commands/read_file.rs
+++ b/src/command/commands/read_file.rs
@@ -88,7 +88,7 @@ mod tests {
     fn read_file_inserts_lines() {
         let base = NamedTempFile::new().unwrap();
         write(base.path(), "one\n").unwrap();
-        let mut extra = NamedTempFile::new().unwrap();
+        let extra = NamedTempFile::new().unwrap();
         write(extra.path(), "a\nb\n").unwrap();
 
         let mut editor = Editor::new();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -570,10 +570,12 @@ impl Editor {
         } else {
             PathBuf::from(".")
         };
-        let file_prefix = path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("");
+        let file_name_os_str = path.file_name().unwrap_or_default();
+        let file_prefix = if partial.is_empty() || (partial == "." && file_name_os_str == std::ffi::OsStr::new(".")) {
+            ""
+        } else {
+            file_name_os_str.to_str().unwrap_or("")
+        };
 
         let entries = match fs::read_dir(&dir) {
             Ok(e) => e,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -542,6 +542,73 @@ impl Editor {
         }
     }
 
+    pub fn complete_ex_command(&mut self) {
+        use std::fs;
+        use std::path::{Path, PathBuf};
+
+        let cursor_byte = Editor::char_to_byte_index(&self.ex_command_data, self.ex_command_cursor);
+        let before_cursor = &self.ex_command_data[..cursor_byte];
+        let start_byte = before_cursor
+            .rfind(|c: char| c.is_whitespace())
+            .map(|i| i + 1)
+            .unwrap_or(0);
+
+        let prefix = before_cursor[..start_byte].trim_start();
+        let command = prefix.split_whitespace().next().unwrap_or("");
+        if command != "w" && command != "r" && command != "o" {
+            return;
+        }
+
+        let partial = &before_cursor[start_byte..];
+        let path = Path::new(partial);
+        let dir = if let Some(parent) = path.parent() {
+            if parent.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                parent.to_path_buf()
+            }
+        } else {
+            PathBuf::from(".")
+        };
+        let file_prefix = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+
+        let entries = match fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        let mut matches: Vec<String> = entries
+            .filter_map(|e| {
+                e.ok().and_then(|e| e.file_name().into_string().ok())
+                    .filter(|name| name.starts_with(file_prefix))
+            })
+            .collect();
+
+        matches.sort();
+        let candidate = match matches.first() {
+            Some(c) => c,
+            None => return,
+        };
+
+        let mut completed_path = dir.join(candidate).to_string_lossy().to_string();
+        if Path::new(&completed_path).is_dir() {
+            completed_path.push('/');
+        }
+
+        let after_cursor = &self.ex_command_data[cursor_byte..];
+        self.ex_command_data = format!(
+            "{}{}{}",
+            &self.ex_command_data[..start_byte],
+            completed_path,
+            after_cursor
+        );
+        let start_chars = self.ex_command_data[..start_byte + completed_path.len()].chars().count();
+        self.ex_command_cursor = start_chars;
+        self.update_ex_command_status();
+    }
+
     pub fn previous_ex_command(&mut self) {
         if self.ex_command_history.is_empty() {
             return;

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -438,7 +438,7 @@ Some(SimpleLineAddressType::LineNumber(number.parse().map_err(|e| GenericError::
             None
         };
 
-        if let Some(mut addr) = base {
+        if let Some(addr) = base {
             let mut offset: isize = 0;
             loop {
                 if self.accept(TokenType::Symbol, "+") {

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -85,6 +85,12 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.backspace_ex_command();
                         }
                         KeyData {
+                            key_code: event::KeyCode::Tab,
+                            ..
+                        } => {
+                            editor.complete_ex_command();
+                        }
+                        KeyData {
                             key_code: event::KeyCode::Left,
                             ..
                         } => {


### PR DESCRIPTION
## Summary
- support completing filenames with Tab during ex commands
- wire up Tab to completion handling in the main loop

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68469ec7e1e4832faec8b6fce4fcf6b4