### PR TITLE
Add caret motion command

### DIFF
--- a/e2e/test_motion_commands.py
+++ b/e2e/test_motion_commands.py
@@ -144,15 +144,13 @@ def test_motion_l_at_eol():
 
 
 def test_motion_caret():
-    # TODO: '^' command is not yet implemented in evi
-    # run_motion_test(
-    #     file_content="  indented text\n",
-    #     terminal_size=(24, 80),
-    #     initial_cursor_pos=(1, 5),
-    #     command_to_test="^",
-    #     expected_cursor_pos=(1, 3),
-    # )
-    pass
+    run_motion_test(
+        file_content="  indented text\n",
+        terminal_size=(24, 80),
+        initial_cursor_pos=(1, 5),
+        command_to_test="^",
+        expected_cursor_pos=(1, 3),
+    )
 
 
 def test_motion_G():

--- a/src/command/factory.rs
+++ b/src/command/factory.rs
@@ -5,21 +5,21 @@ use crate::command::commands::no_op_command::NoOpCommand;
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use super::commands::append::Append;
+use super::commands::append_line_end::AppendLineEnd;
 use super::commands::change::Change;
 use super::commands::delete::{Delete, DeleteChar};
 use super::commands::find_char::{FindChar, RepeatFindChar};
 use super::commands::go_to_file::{GoToFirstLine, GoToLastLine};
 use super::commands::insert::Insert;
 use super::commands::insert_line_start::InsertLineStart;
+use super::commands::join_lines::JoinLines;
+use super::commands::mark::{JumpMark, SetMark};
 use super::commands::misc::DisplayFile;
 use super::commands::open_line::OpenLine;
-use super::commands::join_lines::JoinLines;
 use super::commands::paste::Paste;
-use super::commands::append_line_end::AppendLineEnd;
 use super::commands::search::RepeatSearch;
 use super::commands::undo::Undo;
 use super::commands::yank::Yank;
-use super::commands::mark::{SetMark, JumpMark};
 
 pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
     match command_data {
@@ -59,6 +59,10 @@ pub fn command_factory(command_data: &CommandData) -> Box<dyn Command> {
             key_code: KeyCode::Char('0'),
             ..
         } => Box::new(MoveBeginningOfLine {}),
+        CommandData {
+            key_code: KeyCode::Char('^'),
+            ..
+        } => Box::new(MoveFirstNonBlank {}),
         CommandData {
             key_code: KeyCode::Char('$'),
             ..


### PR DESCRIPTION
## Summary
- implement '^' motion to move to first non-blank character
- map `KeyCode::Char('^')` in command factory
- unit test caret motion
- e2e test caret motion

## Testing
- `cargo test --verbose`
- `pytest e2e --verbose` *(fails: test_cursor_j_k_on_wrapped_line)*
- `pytest e2e/test_motion_commands.py::test_motion_caret -vv`

------
https://chatgpt.com/codex/tasks/task_e_6846ad029e58832fad5d13348aaaa6a6