### PR TITLE
Implement named register operations

### DIFF
--- a/e2e/test_registers.py
+++ b/e2e/test_registers.py
@@ -1,0 +1,6 @@
+from .helpers import run_commands
+
+
+def test_named_register_yank_paste():
+    result = run_commands(['"a', 'yy', 'j', '"ap'], initial_content='one\ntwo\n')
+    assert result.splitlines() == ['one', 'two', 'one', '']

--- a/src/command/commands/yank.rs
+++ b/src/command/commands/yank.rs
@@ -9,6 +9,7 @@ use crate::generic_error::GenericResult;
 pub struct Yank {
     pub jump_command_data_opt: Option<JumpCommandData>,
     pub editor_cursor_data: Option<EditorCursorData>,
+    pub register: Option<char>,
 }
 
 impl Default for Yank {
@@ -16,6 +17,7 @@ impl Default for Yank {
         Self {
             jump_command_data_opt: None,
             editor_cursor_data: None,
+            register: None,
         }
     }
 }
@@ -31,8 +33,9 @@ impl Command for Yank {
             let start = region.start.cursor_position_in_buffer;
             let end = region.end.cursor_position_in_buffer;
             let text = editor.buffer.yank(start, end)?;
-            editor.unnamed_register = text;
-            editor.unnamed_register_linewise = start.col == 0 && end.col == 0;
+            let linewise = start.col == 0 && end.col == 0;
+            let reg = editor.take_pending_register().or(self.register);
+            editor.store_register(reg, text, linewise);
             editor.restore_cursor_data(region.start);
             self.editor_cursor_data = Some(region.start);
         }


### PR DESCRIPTION
## Summary
- support named registers in the editor
- track pending register prefix in main loop
- store yanks and pastes in named registers
- add an end-to-end test exercising named register yank/paste

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e/test_registers.py::test_named_register_yank_paste --verbose`
- `pytest e2e --verbose` *(fails: test_cursor_j_k_on_wrapped_line)*

------
https://chatgpt.com/codex/tasks/task_e_6846b12fd06c832f9207d42de5c47c82