### PR TITLE
Enable repetition of OpenLine

### DIFF
--- a/e2e/test_vi_commands.py
+++ b/e2e/test_vi_commands.py
@@ -58,8 +58,7 @@ def test_join_lines_undo():
 
 def test_open_line_above_repeat():
     result = run_commands(['O', 'first', '\x1b', '.', '\x1b'], initial_content='second\n')
-    # TODO: repeating open line should insert another line but is not implemented yet
-    assert result.splitlines() == ['second']
+    assert result.splitlines() == ['first', 'first', 'second']
 
 
 def test_delete_char():

--- a/src/command/commands/open_line.rs
+++ b/src/command/commands/open_line.rs
@@ -87,8 +87,9 @@ impl Command for OpenLine {
 
     fn redo(&mut self, editor: &mut Editor) -> GenericResult<Option<Box<dyn Command>>> {
         editor.is_dirty = true;
+        let cursor_before = editor.snapshot_cursor_data();
         let new_open = Box::new(OpenLine {
-            editor_cursor_data: self.editor_cursor_data,
+            editor_cursor_data: Some(cursor_before),
             text: self.text.clone(),
             above: self.above,
         });

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -247,11 +247,24 @@ impl Editor {
     }
 
     fn convert_repetitive_command_history_to_commands_history(&mut self) {
+        use crate::command::commands::open_line::OpenLine;
+
         if let Some(mut last_command_chunk) = self.command_history.pop() {
             let mut last_executed_command = last_command_chunk.pop().unwrap();
             last_executed_command
                 .command
                 .set_text(self.last_input_string.clone());
+
+            if last_executed_command.command.is::<OpenLine>() {
+                if let Some(open_line) = last_executed_command
+                    .command
+                    .downcast_ref::<OpenLine>()
+                {
+                    let mut updated = open_line.clone();
+                    updated.editor_cursor_data = Some(self.snapshot_cursor_data());
+                    last_executed_command.command = Box::new(updated);
+                }
+            }
 
             let count = last_executed_command.command_data.count;
             if count == 1 {


### PR DESCRIPTION
## Summary
- update command history conversion for OpenLine
- track cursor on redo
- update expectation for open line repeat

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e/test_vi_commands.py::test_open_line_above_repeat -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6846cf0a519c832f819f27ce79b0040a