### PR TITLE
Lower EVI_PEXPECT_TIMEOUT defaults

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -45,7 +45,7 @@ To increase reliability, you can adjust the following environment variables:
 
 - `EVI_DELAY_BEFORE_SEND` – Delay (in seconds) before sending each keystroke to `evi` (default: 0.1s).
 - `EVI_DELAY_AFTER_ESC` – Delay (in seconds) after sending an Escape (ESC) key (default: 0.05s).
-- `EVI_PEXPECT_TIMEOUT` – Timeout (in seconds) for `pexpect` when waiting for `evi`'s output (default: 1s).
+- `EVI_PEXPECT_TIMEOUT` – Timeout (in seconds) for `pexpect` when waiting for `evi`'s output (default: 0.2s).
 
 Example command:
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -10,10 +10,12 @@ EVI_BIN = os.path.join(ROOT_DIR, 'target', 'debug', 'evi')
 os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.1')
 # Slow execution environments (like the Codex workspace container) may take
 # longer to output screen updates. ``EVI_PEXPECT_TIMEOUT`` controls how long the
-# helper functions wait when reading from the spawned ``evi`` process.  The
-# default of ``0.3`` seconds is sometimes too short here which leads to spurious
-# timeouts.  Increase it slightly unless it has been configured explicitly.
-os.environ.setdefault('EVI_PEXPECT_TIMEOUT', '1')
+# helper functions wait when reading from the spawned ``evi`` process.  A lower
+# timeout speeds up the tests on faster machines, but may need to be increased
+# if spurious ``pexpect.TIMEOUT`` errors occur.  We therefore use a relatively
+# small default of ``0.2`` seconds and allow callers to override it via the
+# ``EVI_PEXPECT_TIMEOUT`` environment variable if required.
+os.environ.setdefault('EVI_PEXPECT_TIMEOUT', '0.2')
 
 @pytest.fixture(scope='session', autouse=True)
 def build_evi():

--- a/e2e/test_motion_commands.py
+++ b/e2e/test_motion_commands.py
@@ -33,10 +33,10 @@ def get_screen_and_cursor(child: pexpect.spawn, rows: int = 24) -> Tuple[str, Tu
     child.expect(r"line (\d+) of \d+ --\d+%-- col (\d+)")
     screen = child.before + child.after
     # Allow the timeout when reading screen updates to be configured via the
-    # ``EVI_PEXPECT_TIMEOUT`` environment variable. A slightly longer timeout is
-    # helpful in slower CI containers where ``read_nonblocking`` may otherwise
-    # raise ``pexpect.TIMEOUT`` while there is still output pending.
-    timeout = float(os.getenv("EVI_PEXPECT_TIMEOUT", "0.3"))
+    # ``EVI_PEXPECT_TIMEOUT`` environment variable.  The helper functions use a
+    # default of ``0.2`` seconds which keeps the tests fast, but this can be
+    # increased in slower CI containers to avoid ``pexpect.TIMEOUT`` errors.
+    timeout = float(os.getenv("EVI_PEXPECT_TIMEOUT", "0.2"))
     try:
         screen += child.read_nonblocking(size=4096, timeout=timeout)
     except (pexpect.exceptions.TIMEOUT, pexpect.exceptions.EOF):


### PR DESCRIPTION
## Summary
- lower the default EVI_PEXPECT_TIMEOUT to 0.2s
- document the new value
- adjust test timeout logic

## Testing
- `pip install -r e2e/requirements.txt`
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_6846f01f21fc832f86ffc8e646792566