### PR TITLE
Reduce default e2e delays

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -43,14 +43,14 @@ This script builds the Docker image based on the official `rust` image, mounts t
 When running in slower containers, `pexpect` may time out before `evi` responds.
 To increase reliability, you can adjust the following environment variables:
 
-- `EVI_DELAY_BEFORE_SEND` – Delay (in seconds) before sending each keystroke to `evi` (default: 0.1s).
-- `EVI_DELAY_AFTER_ESC` – Delay (in seconds) after sending an Escape (ESC) key (default: 0.05s).
+- `EVI_DELAY_BEFORE_SEND` – Delay (in seconds) before sending each keystroke to `evi` (default: 0.01s).
+- `EVI_DELAY_AFTER_ESC` – Delay (in seconds) after sending an Escape (ESC) key (default: 0.005s).
 - `EVI_PEXPECT_TIMEOUT` – Timeout (in seconds) for `pexpect` when waiting for `evi`'s output (default: 0.2s).
 
 Example command:
 
 ```bash
-EVI_PEXPECT_TIMEOUT=2 EVI_DELAY_BEFORE_SEND=0.2 pytest e2e --verbose
+EVI_DELAY_BEFORE_SEND=0.01 EVI_DELAY_AFTER_ESC=0.005 pytest e2e --verbose
 ```
 
-Higher values may be required when running inside the Codex workspace.
+Adjust the values as necessary; higher values may be required when running inside the Codex workspace.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -6,8 +6,10 @@ ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 EVI_BIN = os.path.join(ROOT_DIR, 'target', 'debug', 'evi')
 
 # Increase the delay between keystrokes to avoid timing issues in slow
-# environments such as CI containers.
-os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.1')
+# environments such as CI containers.  The tests run faster with smaller
+# defaults but callers can override these values if needed.
+os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.01')
+os.environ.setdefault('EVI_DELAY_AFTER_ESC', '0.005')
 # Slow execution environments (like the Codex workspace container) may take
 # longer to output screen updates. ``EVI_PEXPECT_TIMEOUT`` controls how long the
 # helper functions wait when reading from the spawned ``evi`` process.  A lower


### PR DESCRIPTION
## Summary
- lower the e2e test delay defaults in `conftest.py`
- document the new defaults and example command in `e2e/README.md`

## Testing
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose` *(fails: pexpect.exceptions.TIMEOUT)*

------
https://chatgpt.com/codex/tasks/task_e_6846f4b10000832fa3d0960d2197cdfa