### PR TITLE
Update e2e docs and fixture for xdist

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,10 +16,11 @@ The tests automatically build the `evi` binary using Cargo before running.
 
 ## Running the tests
 
+The tests use the `pytest-xdist` plugin so they can be run in parallel.
 Execute all e2e tests with:
 
 ```bash
-pytest
+pytest -n auto
 ```
 
 Specific tests can be selected in the usual `pytest` ways, e.g.:
@@ -37,6 +38,14 @@ scripts/e2e_docker.sh
 ```
 
 This script builds the Docker image based on the official `rust` image, mounts the project directory into the container, and runs `cargo build --verbose` followed by `pytest e2e --verbose`. The Docker image installs the Python dependencies in a virtual environment to avoid system package conflicts.
+
+Because `scripts/e2e_docker.sh` forwards extra arguments to `pytest` via the
+`PYTEST_ARGS` environment variable, you can enable parallel execution. For
+example:
+
+```bash
+scripts/e2e_docker.sh -n auto e2e --verbose
+```
 
 ## Handling slow environments
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -21,4 +21,5 @@ os.environ.setdefault('EVI_PEXPECT_TIMEOUT', '0.2')
 
 @pytest.fixture(scope='session', autouse=True)
 def build_evi():
-    subprocess.run(['cargo', 'build'], cwd=ROOT_DIR, check=True)
+    if not os.path.exists(EVI_BIN):
+        subprocess.run(['cargo', 'build'], cwd=ROOT_DIR, check=True)

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,2 +1,3 @@
 pexpect
 pytest
+pytest-xdist


### PR DESCRIPTION
## Summary
- note that `pytest-xdist` is required for the e2e tests
- show running tests in parallel and docker example
- add `pytest-xdist` to requirements
- avoid rebuilding `evi` binary if already built

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest e2e --verbose` *(fails: TIMEOUT)*

------
https://chatgpt.com/codex/tasks/task_e_6846f6a7e4d4832f9f523d46e7dbae86