### PR TITLE
Fix e2e test timeouts on slow containers

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -8,8 +8,13 @@ EVI_BIN = os.path.join(ROOT_DIR, 'target', 'debug', 'evi')
 # Increase the delay between keystrokes to avoid timing issues in slow
 # environments such as CI containers.  The tests run faster with smaller
 # defaults but callers can override these values if needed.
-os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.01')
-os.environ.setdefault('EVI_DELAY_AFTER_ESC', '0.005')
+# Earlier versions used very small defaults to keep the tests fast.  However
+# this proved unreliable on slower systems such as the Codex container where
+# keystrokes can be dropped if sent too quickly.  Use more conservative
+# defaults so the tests pass consistently even without tweaking environment
+# variables.
+os.environ.setdefault('EVI_DELAY_BEFORE_SEND', '0.1')
+os.environ.setdefault('EVI_DELAY_AFTER_ESC', '0.1')
 # Slow execution environments (like the Codex workspace container) may take
 # longer to output screen updates. ``EVI_PEXPECT_TIMEOUT`` controls how long the
 # helper functions wait when reading from the spawned ``evi`` process.  A lower


### PR DESCRIPTION
## Summary
- bump the default EVI_DELAY_BEFORE_SEND and EVI_DELAY_AFTER_ESC values
  in `e2e/conftest.py` so tests reliably pass on slower machines

## Testing
- `cargo test --verbose`
- `pytest -n auto e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_6846fb19b99c832fba3400a7d4d3c381