### PR TITLE
Reduce noisy logging

### DIFF
--- a/src/command/commands/append.rs
+++ b/src/command/commands/append.rs
@@ -1,4 +1,3 @@
-use log::info;
 use std::any::Any;
 
 use crate::command::base::Command;
@@ -72,8 +71,6 @@ impl Command for Append {
                 if input_text_lines.len() == 0 {
                     panic!("input_text_lines.len() == 0, text: '{:?}'", text);
                 }
-                info!("input_text_lines: {:?}", input_text_lines);
-                info!("input_text_lines.len(): {:?}", input_text_lines.len());
                 if input_text_lines.len() == 1 {
                     let line = &editor.buffer.lines[row];
                     let new_line: String = line

--- a/src/command/commands/go_to_line.rs
+++ b/src/command/commands/go_to_line.rs
@@ -13,10 +13,7 @@ pub struct GoToLineCommand {
 
 impl Command for GoToLineCommand {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        log::info!("GoToLineCommand execute");
         let line_number = editor.get_line_number_from(&self.line_address);
-
-        log::info!("line_number: {}", line_number);
         editor.cursor_position_in_buffer.row = 0;
         editor.cursor_position_in_buffer.col = 0;
         editor.cursor_position_on_screen.row = 0;

--- a/src/command/commands/insert.rs
+++ b/src/command/commands/insert.rs
@@ -1,7 +1,5 @@
 use std::any::Any;
 
-use log::info;
-
 use crate::command::base::Command;
 use crate::editor::Editor;
 use crate::generic_error::GenericResult;
@@ -59,8 +57,6 @@ impl Command for Insert {
                 if input_text_lines.len() == 0 {
                     panic!("input_text_lines.len() == 0, text: '{:?}'", text);
                 }
-                info!("input_text_lines: {:?}", input_text_lines);
-                info!("input_text_lines.len(): {:?}", input_text_lines.len());
                 if input_text_lines.len() == 1 {
                     let line = &editor.buffer.lines[row];
                     let new_line: String = line
@@ -74,8 +70,10 @@ impl Command for Insert {
                     let first_line = editor.buffer.lines[row].clone();
                     let last_line = editor.buffer.lines[row + input_text_lines.len() - 1].clone();
                     let new_first_line: String = first_line.chars().take(col).collect();
-                    let new_last_line: String =
-                        last_line.chars().skip(last_input_line.chars().count()).collect();
+                    let new_last_line: String = last_line
+                        .chars()
+                        .skip(last_input_line.chars().count())
+                        .collect();
                     editor.buffer.lines[row] = new_first_line + new_last_line.as_str();
                     for _ in 0..input_text_lines.len() - 1 {
                         editor.buffer.lines.remove(row + 1);

--- a/src/command/commands/print.rs
+++ b/src/command/commands/print.rs
@@ -14,8 +14,6 @@ pub struct PrintCommand {
 
 impl Command for PrintCommand {
     fn execute(&mut self, editor: &mut Editor) -> GenericResult<()> {
-        log::info!("PrintCommand execute");
-
         if editor.buffer.lines.is_empty() {
             return Ok(());
         }

--- a/src/command/compose.rs
+++ b/src/command/compose.rs
@@ -1,7 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use log::info;
-
 use crate::command::base::{CommandData, JumpCommandData};
 use crate::command::key_codes::{
     is_ctrl_command, is_editing_command_with_range, is_editing_command_without_range,
@@ -46,8 +44,6 @@ pub enum InputState {
 
 // Take vi command input, interpret it, and generate commands
 pub fn compose(key_events: &Vec<KeyEvent>) -> InputState {
-    info!("compose: {:?}", key_events);
-
     let mut input_state = InputState::Start;
 
     for event in key_events {
@@ -62,7 +58,6 @@ pub fn compose(key_events: &Vec<KeyEvent>) -> InputState {
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                info!("Esc");
                 return InputState::CommandCompleted(CommandData {
                     count: 1,
                     key_code: KeyCode::Esc,
@@ -394,7 +389,6 @@ pub fn compose(key_events: &Vec<KeyEvent>) -> InputState {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                info!("Enter");
                 return InputState::CommandCompleted(CommandData {
                     count: 1,
                     key_code: KeyCode::Enter,
@@ -403,7 +397,7 @@ pub fn compose(key_events: &Vec<KeyEvent>) -> InputState {
                 });
             }
             _ => {
-                info!("Other key: {:?}", event);
+                // unhandled key
                 ()
             }
         }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7,8 +7,6 @@ use crossterm::{
     ExecutableCommand,
 };
 
-use log::info;
-
 use crate::render::render;
 use crate::{
     buffer::Buffer,
@@ -201,7 +199,6 @@ impl Editor {
     }
 
     pub fn resize_terminal(&mut self, width: u16, height: u16) {
-        info!("Resize terminal to width: {}, height: {}", width, height);
         self.terminal_size = TerminalSize { width, height };
         if self.cursor_position_on_screen.col >= width {
             self.cursor_position_on_screen.col = width - 1;
@@ -256,10 +253,7 @@ impl Editor {
                 .set_text(self.last_input_string.clone());
 
             if last_executed_command.command.is::<OpenLine>() {
-                if let Some(open_line) = last_executed_command
-                    .command
-                    .downcast_ref::<OpenLine>()
-                {
+                if let Some(open_line) = last_executed_command.command.downcast_ref::<OpenLine>() {
                     let mut updated = open_line.clone();
                     updated.editor_cursor_data = open_line.editor_cursor_data;
                     last_executed_command.command = Box::new(updated);
@@ -282,7 +276,6 @@ impl Editor {
             } else {
                 panic!("count: {}", count);
             }
-            info!("input string: {}", self.last_input_string);
         }
     }
 
@@ -300,7 +293,6 @@ impl Editor {
                     command_data: command_data.clone(),
                     command,
                 });
-                info!("command_series.len(): {}", command_series.len());
                 if let Ok(Some(next_command)) = redo_result {
                     command_opt = Some(next_command);
                 } else {
@@ -314,9 +306,7 @@ impl Editor {
                 command_data: command_data.clone(),
                 command,
             });
-            info!("command_series.len(): {}", command_series.len());
         }
-        info!("### command_series.len(): {}", command_series.len());
         self.last_command = Some(command_series.clone());
         self.command_history.push(command_series);
     }
@@ -500,7 +490,6 @@ impl Editor {
         let mut parser = Parser::new(ex_command_str);
         let result = parser.parse();
         if let Err(e) = result {
-            info!("Error: {}", e.to_string());
             self.status_line = e.to_string();
             self.ex_command_data = "".to_string();
             return Ok(());
@@ -1422,7 +1411,6 @@ impl Editor {
 
 impl Drop for Editor {
     fn drop(&mut self) {
-        info!("Drop Editor");
         let mut stdout = std::io::stdout();
         terminal::disable_raw_mode().unwrap();
         stdout.execute(terminal::Clear(ClearType::All)).unwrap();

--- a/src/ex/parser.rs
+++ b/src/ex/parser.rs
@@ -18,7 +18,6 @@ use crate::generic_error::GenericError;
 
 use crate::command::commands::exit;
 use crate::command::commands::print;
-use log::debug;
 use crate::command::commands::write;
 use crate::command::commands::reload::ReloadFileCommand;
 use crate::command::commands::read_file;
@@ -61,7 +60,6 @@ pub struct Parser {
 impl Parser {
     pub fn new(input: &str) -> Self {
         let tokens = lexer::tokenize(input);
-        debug!("tokens {:?}", tokens);
         Parser {
             original_tokens: tokens.clone(),
             tokens,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,11 @@ mod generic_error;
 mod util;
 mod ex;
 
-use log::{error, info};
+use log::error;
 
 fn main() {
     log4rs::init_file("log4rs.yml", Default::default()).unwrap();
 
-    info!("Start the editor");
 
     let mut editor = editor::Editor::from_cmd_args(std::env::args().collect());
     if let Err(e) = main_loop::main_loop(&mut editor) {

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -6,7 +6,7 @@ use crossterm::{
 use std::io::stdout;
 use std::io::Write;
 
-use log::{error, info};
+use log::error;
 
 use crate::command::compose::{compose, InputState, KeyData};
 use crate::editor::Editor;
@@ -28,7 +28,6 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
         match result {
             Ok(Event::Key(key_event)) => {
                 if editor.is_command_mode() {
-                    info!("Key event: {:?}", key_event);
                     if awaiting_register {
                         if let event::KeyCode::Char(c) = key_event.code {
                             editor.pending_register = Some(c);
@@ -55,7 +54,6 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                         let input_state = compose(&event_keys);
                         match input_state {
                             InputState::CommandCompleted(command_data) => {
-                                info!("Command completed: {:?}", command_data);
                                 editor.execute_command(command_data)?;
                                 event_keys.clear();
                             }
@@ -65,9 +63,7 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                                 editor.display_visual_bell()?;
                                 event_keys.clear();
                             }
-                            _ => {
-                                info!("Input state: {:?}", input_state);
-                            }
+                            _ => {}
                         }
                     }
                 } else if editor.is_ex_command_mode() {
@@ -293,7 +289,7 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                 editor.resize_terminal(width, height);
             }
             _ => {
-                info!("Other event: {:?}", result)
+                // ignore other events
             }
         }
         if editor.should_exit {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
 use crossterm::{cursor, style, terminal, QueueableCommand};
-use log::info;
 
 use crate::{
     editor::{Editor, TerminalSize},
@@ -10,7 +9,6 @@ use crate::{
 };
 
 pub fn render(editor: &mut Editor, stdout: &mut std::io::Stdout) -> GenericResult<()> {
-    info!("render");
     let mut stdout = stdout.lock();
     stdout.queue(terminal::Clear(terminal::ClearType::All))?;
     stdout.queue(cursor::MoveTo(0, 0))?;


### PR DESCRIPTION
## Summary
- remove various `info!` and `debug!` log calls
- drop unused log imports

## Testing
- `cargo test --verbose`
- `pytest -n auto e2e --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6846fdcf632c832fae68cecffbdd0d06