### PR TITLE
Fix empty string inserts

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -75,9 +75,12 @@ impl Buffer {
     }
 
     pub fn insert(&mut self, row: usize, col: usize, s: &str) -> GenericResult<()> {
+        if s.is_empty() {
+            return Ok(());
+        }
         let lines_to_be_inserted = split_line(s);
         if lines_to_be_inserted.len() == 0 {
-            panic!("lines.len() == 0, s: '{:?}'", s);
+            return Ok(());
         }
         if lines_to_be_inserted.len() == 1 {
             let new_line = self.lines[row]
@@ -304,6 +307,16 @@ mod tests {
         };
         buffer.insert(0, 1, "x\ny").unwrap();
         assert_eq!(buffer.lines, vec!["ax".to_string(), "ybc".to_string(), "def".to_string()]);
+    }
+
+    #[test]
+    fn test_insert_empty_string() {
+        let mut buffer = Buffer {
+            lines: vec!["abc".to_string()],
+        };
+        let original = buffer.lines.clone();
+        buffer.insert(0, 1, "").unwrap();
+        assert_eq!(buffer.lines, original);
     }
 
     #[test]

--- a/src/command/commands/insert.rs
+++ b/src/command/commands/insert.rs
@@ -51,11 +51,16 @@ impl Command for Insert {
     fn undo(&mut self, editor: &mut Editor) -> GenericResult<()> {
         if let Some(original_cursor_data) = self.editor_cursor_data {
             if let Some(text) = &self.text {
+                if text.is_empty() {
+                    editor.restore_cursor_data(original_cursor_data);
+                    return Ok(());
+                }
                 let row = original_cursor_data.cursor_position_in_buffer.row;
                 let col = original_cursor_data.cursor_position_in_buffer.col;
                 let input_text_lines: Vec<&str> = split_line(text);
-                if input_text_lines.len() == 0 {
-                    panic!("input_text_lines.len() == 0, text: '{:?}'", text);
+                if input_text_lines.is_empty() {
+                    editor.restore_cursor_data(original_cursor_data);
+                    return Ok(());
                 }
                 if input_text_lines.len() == 1 {
                     let line = &editor.buffer.lines[row];
@@ -93,6 +98,9 @@ impl Command for Insert {
         });
 
         if let Some(input_text) = &self.text {
+            if input_text.is_empty() {
+                return Ok(Some(new_insert));
+            }
             for c in input_text.chars() {
                 if c == '\n' {
                     editor.append_new_line()?
@@ -107,5 +115,27 @@ impl Command for Insert {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::Editor;
+
+    #[test]
+    fn insert_empty_string() {
+        let mut editor = Editor::new();
+        editor.terminal_size = crate::editor::TerminalSize { width: 80, height: 24 };
+        editor.buffer.lines = vec!["hello".to_string()];
+        let mut cmd = Insert::default();
+        cmd.execute(&mut editor).unwrap();
+        editor.set_command_mode();
+        cmd.set_text(String::new());
+        let before = editor.buffer.lines.clone();
+        cmd.redo(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, before);
+        cmd.undo(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, before);
     }
 }

--- a/src/command/commands/insert_line_start.rs
+++ b/src/command/commands/insert_line_start.rs
@@ -57,11 +57,16 @@ impl Command for InsertLineStart {
             (self.insert_cursor_data, self.original_cursor_data)
         {
             if let Some(text) = &self.text {
+                if text.is_empty() {
+                    editor.restore_cursor_data(original_cd);
+                    return Ok(());
+                }
                 let row = insert_cd.cursor_position_in_buffer.row;
                 let col = insert_cd.cursor_position_in_buffer.col;
                 let input_text_lines: Vec<&str> = split_line(text);
-                if input_text_lines.len() == 0 {
-                    panic!("input_text_lines.len() == 0, text: '{:?}'", text);
+                if input_text_lines.is_empty() {
+                    editor.restore_cursor_data(original_cd);
+                    return Ok(());
                 }
                 if input_text_lines.len() == 1 {
                     let line = &editor.buffer.lines[row];
@@ -101,6 +106,9 @@ impl Command for InsertLineStart {
         move_bol.execute(editor)?;
 
         if let Some(input_text) = &self.text {
+            if input_text.is_empty() {
+                return Ok(Some(new_cmd));
+            }
             for c in input_text.chars() {
                 if c == '\n' {
                     editor.append_new_line()?;
@@ -140,6 +148,22 @@ mod tests {
         cmd.undo(&mut editor).unwrap();
         assert_eq!(editor.buffer.lines[0], "hello");
         assert_eq!(editor.cursor_position_in_buffer.col, 3);
+    }
+
+    #[test]
+    fn insert_line_start_empty_string() {
+        let mut editor = Editor::new();
+        editor.terminal_size = crate::editor::TerminalSize { width: 80, height: 24 };
+        editor.buffer.lines = vec!["hello".to_string()];
+        let mut cmd = InsertLineStart::default();
+        cmd.execute(&mut editor).unwrap();
+        editor.set_command_mode();
+        cmd.set_text(String::new());
+        let before = editor.buffer.lines.clone();
+        cmd.redo(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, before);
+        cmd.undo(&mut editor).unwrap();
+        assert_eq!(editor.buffer.lines, before);
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid modifying the buffer when inserting an empty string
- make Append/Insert/... commands no-op for empty text
- test handling of empty string inserts

## Testing
- `cargo test --verbose`
- `pytest -n auto e2e --verbose` *(fails: test_cursor_j_k_on_wrapped_line)*

------
https://chatgpt.com/codex/tasks/task_e_68471e2aec9c832fb0ac5a7296ac0c7a