### PR TITLE
Fix upward scrolling for wrapped lines

### DIFF
--- a/e2e/test_wrapping.py
+++ b/e2e/test_wrapping.py
@@ -147,6 +147,35 @@ def test_scroll_past_wrapped_top_line():
         os.unlink(path)
 
 
+def test_scroll_up_into_wrapped_line():
+    header = "# title"
+    long_line = "x" * 196
+    other_lines = "\n".join(str(i) for i in range(4, 15))
+    file_content = f"{header}\n\n{long_line}\n{other_lines}\n"
+    fd, path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(file_content)
+
+        env = os.environ.copy()
+        env.setdefault("TERM", "xterm")
+        child = pexpect.spawn(EVI_BIN, [path], env=env, encoding="utf-8")
+        child.delaybeforesend = float(os.getenv("EVI_DELAY_BEFORE_SEND", "0.1"))
+        child.setwinsize(10, 60)
+
+        get_screen_and_cursor(child)
+        child.send("j" * 8)
+        child.send("k" * 6)
+        screen, _ = get_screen_and_cursor(child)
+        lines = _parse_screen(screen)
+        assert lines[1].startswith("x" * 60)
+
+        child.send(":q!\r")
+        child.expect(pexpect.EOF)
+    finally:
+        os.unlink(path)
+
+
 # def test_full_width_lines_no_extra_blank_lines():
 #     file_content = "{}\n{}\n{}\n".format("A" * 80, "B" * 80, "C" * 80)
 #     fd, path = tempfile.mkstemp()

--- a/src/command/commands/move_cursor.rs
+++ b/src/command/commands/move_cursor.rs
@@ -216,21 +216,15 @@ impl Command for PreviousLine {
             editor.cursor_position_in_buffer.row -= 1;
 
             let line = &editor.buffer.lines[editor.cursor_position_in_buffer.row];
-            let num_of_chars = line.chars().count();
-            let num_of_lines_on_screen = if num_of_chars == 0 {
-                1
-            } else if num_of_chars % editor.terminal_size.width as usize == 0 {
-                num_of_chars / editor.terminal_size.width as usize
-            } else {
-                num_of_chars / editor.terminal_size.width as usize + 1
-            };
+            let num_of_lines_on_screen =
+                get_line_height(line, editor.terminal_size.width);
 
             if editor.cursor_position_on_screen.row >= num_of_lines_on_screen as u16 {
                 editor.cursor_position_on_screen.row -= num_of_lines_on_screen as u16;
-            } else if editor.window_position_in_buffer.row >= num_of_lines_on_screen {
-                editor.window_position_in_buffer.row -= num_of_lines_on_screen;
             } else {
-                editor.window_position_in_buffer.row = 0;
+                editor.window_position_in_buffer.row =
+                    editor.window_position_in_buffer.row.saturating_sub(1);
+                editor.cursor_position_on_screen.row = 0;
             }
 
             let mut forward_char = ForwardChar {};


### PR DESCRIPTION
## Summary
- fix PreviousLine scroll logic so moving up into wrapped lines doesn't overscroll to file start
- add regression test for scrolling up into wrapped lines

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pip install -r e2e/requirements.txt`
- `pytest -n auto e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_6896ea82f570832fb2e934d5f2ee92c2