### PR TITLE
Support backspace in ex command mode

### DIFF
--- a/e2e/test_ex_backspace.py
+++ b/e2e/test_ex_backspace.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import pexpect
+from .conftest import EVI_BIN
+
+
+def test_ex_command_backspace():
+    fd, path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write('a\nb\n')
+
+        env = os.environ.copy()
+        env.setdefault('TERM', 'xterm')
+
+        child = pexpect.spawn(EVI_BIN, [path], env=env, encoding='utf-8')
+        child.delaybeforesend = float(os.getenv('EVI_DELAY_BEFORE_SEND', '0.1'))
+
+        child.send(':qz')
+        child.sendcontrol('h')
+        child.send('\r')
+
+        child.expect(pexpect.EOF, timeout=5)
+    finally:
+        os.unlink(path)
+

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -277,6 +277,15 @@ impl Editor {
         }
     }
 
+    pub fn delete_last_ex_command_char(&mut self) {
+        if self.ex_command_data.is_empty() {
+            self.set_command_mode();
+        } else {
+            self.ex_command_data.pop();
+            self.status_line = ":".to_owned() + &self.ex_command_data;
+        }
+    }
+
     pub fn snapshot_cursor_data(&self) -> EditorCursorData {
         EditorCursorData {
             cursor_position_on_screen: self.cursor_position_on_screen,

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -69,6 +69,25 @@ pub fn main_loop(editor: &mut Editor) -> GenericResult<()> {
                             editor.set_command_mode();
                             editor.status_line = "".to_string();
                         }
+                        KeyData {
+                            key_code: event::KeyCode::Backspace,
+                            ..
+                        }
+                        | KeyData {
+                            key_code: event::KeyCode::Char('\u{8}'),
+                            ..
+                        }
+                        | KeyData {
+                            key_code: event::KeyCode::Char('\u{7f}'),
+                            ..
+                        }
+                        | KeyData {
+                            key_code: event::KeyCode::Char('h'),
+                            modifiers: KeyModifiers::CONTROL,
+                            ..
+                        } => {
+                            editor.delete_last_ex_command_char();
+                        }
                         _ => {
                             editor.append_ex_command(key_data);
                         }


### PR DESCRIPTION
## Summary
- allow backspace to edit ex command line and exit when empty
- test ex command backspace behavior

## Testing
- `cargo build --verbose`
- `cargo test --verbose`
- `pytest -n auto e2e --verbose`


------
https://chatgpt.com/codex/tasks/task_e_6897037adcc8832f8d1743e8ff4dd098